### PR TITLE
MODUSERSKC-7: users-keycloak/users/{uuid} expects wrong "accept" header content-type

### DIFF
--- a/src/main/java/org/folio/uk/controller/ForgottenUsernamePasswordController.java
+++ b/src/main/java/org/folio/uk/controller/ForgottenUsernamePasswordController.java
@@ -14,13 +14,13 @@ public class ForgottenUsernamePasswordController implements ForgottenUsernamePas
   private final ForgottenUsernamePasswordService service;
 
   @Override
-  public ResponseEntity<Void> recoverForgottenUsername(Identifier identifier) {
+  public ResponseEntity<String> recoverForgottenUsername(Identifier identifier) {
     service.recoverForgottenUsername(identifier);
     return ResponseEntity.noContent().build();
   }
 
   @Override
-  public ResponseEntity<Void> resetForgottenPassword(Identifier identifier) {
+  public ResponseEntity<String> resetForgottenPassword(Identifier identifier) {
     service.resetForgottenPassword(identifier);
     return ResponseEntity.noContent().build();
   }

--- a/src/main/java/org/folio/uk/controller/MigrationController.java
+++ b/src/main/java/org/folio/uk/controller/MigrationController.java
@@ -27,7 +27,7 @@ public class MigrationController implements MigrationApi {
   }
 
   @Override
-  public ResponseEntity<Void> deleteMigration(UUID id) {
+  public ResponseEntity<String> deleteMigration(UUID id) {
     service.deleteMigrationById(id);
     return ResponseEntity.status(NO_CONTENT).build();
   }

--- a/src/main/java/org/folio/uk/controller/PasswordResetController.java
+++ b/src/main/java/org/folio/uk/controller/PasswordResetController.java
@@ -22,13 +22,13 @@ public class PasswordResetController implements PasswordResetApi {
   }
 
   @Override
-  public ResponseEntity<Void> passwordReset(PasswordReset passwordReset) {
+  public ResponseEntity<String> passwordReset(PasswordReset passwordReset) {
     service.resetPassword(passwordReset.getNewPassword());
     return ResponseEntity.noContent().build();
   }
 
   @Override
-  public ResponseEntity<Void> validatePasswordResetLink() {
+  public ResponseEntity<String> validatePasswordResetLink() {
     service.validateLink();
     return ResponseEntity.noContent().build();
   }

--- a/src/main/java/org/folio/uk/controller/UserController.java
+++ b/src/main/java/org/folio/uk/controller/UserController.java
@@ -36,13 +36,13 @@ public class UserController implements UsersApi {
   }
 
   @Override
-  public ResponseEntity<Void> updateUser(UUID id, User user) {
+  public ResponseEntity<String> updateUser(UUID id, User user) {
     service.updateUser(id, user);
     return ResponseEntity.status(NO_CONTENT).build();
   }
 
   @Override
-  public ResponseEntity<Void> deleteUser(UUID id) {
+  public ResponseEntity<String> deleteUser(UUID id) {
     service.deleteUser(id);
     return ResponseEntity.status(NO_CONTENT).build();
   }

--- a/src/main/resources/swagger.api/users-keycloak.yaml
+++ b/src/main/resources/swagger.api/users-keycloak.yaml
@@ -70,6 +70,10 @@ paths:
       responses:
         '204':
           description: All selected users deleted
+          content:
+            text/plain:
+              schema:
+                type: string
         '400':
           $ref: '#/components/responses/badRequest'
         '500':
@@ -91,6 +95,10 @@ paths:
               $ref: '#/components/schemas/user'
       responses:
         '204':
+          content:
+            text/plain:
+              schema:
+                type: string
           description: User successfully updated
         '400':
           $ref: '#/components/responses/badRequest'
@@ -128,6 +136,10 @@ paths:
       responses:
         '204':
           description: User deleted successfully
+          content:
+            text/plain:
+              schema:
+                type: string
         '400':
           $ref: '#/components/responses/badRequest'
         '404':
@@ -228,6 +240,10 @@ paths:
       responses:
         '204':
           description: Delete a user migration
+          content:
+            text/plain:
+              schema:
+                type: string
   /users-keycloak/forgotten/password:
     post:
       description: called when a user has forgotten a password
@@ -264,6 +280,10 @@ paths:
       responses:
         '204':
           description: "Successful call to forgotten username"
+          content:
+            text/plain:
+              schema:
+                type: string
         '400':
           $ref: '#/components/responses/badRequest'
         '422':
@@ -283,6 +303,10 @@ paths:
       responses:
         '204':
           description: "Successful password reset"
+          content:
+            text/plain:
+              schema:
+                type: string
         '400':
           $ref: '#/components/responses/badRequest'
         '422':
@@ -376,6 +400,10 @@ components:
   responses:
     noContent:
       description: Success, no content
+      content:
+        text/plain:
+          schema:
+            type: string
     badRequest:
       description: Bad request, e.g. malformed request body or query parameter
       content:

--- a/src/test/java/org/folio/uk/it/UserIT.java
+++ b/src/test/java/org/folio/uk/it/UserIT.java
@@ -3,12 +3,15 @@ package org.folio.uk.it;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.test.TestConstants.TENANT_ID;
+import static org.folio.test.TestUtils.asJsonString;
 import static org.folio.test.TestUtils.parseResponse;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.TEXT_PLAIN;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -306,6 +309,22 @@ class UserIT extends BaseIntegrationTest {
     var user = TestConstants.user(userId, "update-user", "uu@mail.com");
     doPost("/users-keycloak/users?keycloakOnly=true", user);
     doPut("/users-keycloak/users/{id}", user, userId);
+  }
+
+  @Test
+  @WireMockStub(scripts = {
+    "/wiremock/stubs/users/update-user.json",
+  })
+  void update_with_accept_text_positive() throws Exception {
+    var userId = "202a8ef0-d07b-4626-ad41-48c2d50d9099";
+    var user = TestConstants.user(userId, "update-user", "uu@mail.com");
+    doPost("/users-keycloak/users?keycloakOnly=true", user);
+
+    mockMvc.perform(put("/users-keycloak/users/{id}", userId)
+      .headers(okapiHeaders())
+      .content(asJsonString(user))
+      .contentType(APPLICATION_JSON)
+      .accept(TEXT_PLAIN)).andExpect(status().isNoContent());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
PUT requests to /users-keycloak/users/SOME_UUID are rejected with [response code 406](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406) unless they contain the HTTP Request header accept: application/javascript, even though the response body is empty. This is inconsistent with other FOLIO APIs which all accept PUT requests with the HTTP request header accept: text/plain.

This prevents the UI from being able to save changes to user records.

[MODUSERSKC-7](https://issues.folio.org/browse/MODUSERSKC-7)

## Approach

- Updated swagger yaml with text/plain response type
## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
