### PR TITLE
MODUSERSKC-12 Move reset token to query params using mod-configuration

### DIFF
--- a/src/test/java/org/folio/uk/it/GeneratePasswordResetLinkIT.java
+++ b/src/test/java/org/folio/uk/it/GeneratePasswordResetLinkIT.java
@@ -82,7 +82,7 @@ class GeneratePasswordResetLinkIT extends BaseIntegrationTest {
   @WireMockStub(scripts = "/wiremock/stubs/login/reset-existing-password.json")
   @WireMockStub(scripts = "/wiremock/stubs/notify/create-password-reset-notification.json")
   void generatePasswordResetLink_positive_resetPasswordWithDefaultExpirationTime() throws Exception {
-    var expectedLink = MOCK_FOLIO_UI_HOST + DEFAULT_UI_URL + '/' + RESET_PASSWORD_TOKEN;
+    var expectedLink = getExpectedPasswordResetLink();
 
     callGeneratePasswordResetLink()
       .andExpectAll(status().isOk(),
@@ -109,7 +109,24 @@ class GeneratePasswordResetLinkIT extends BaseIntegrationTest {
   @WireMockStub(scripts = "/wiremock/stubs/login/reset-non-existing-password.json")
   @WireMockStub(scripts = "/wiremock/stubs/notify/create-password-reset-notification.json")
   void generatePasswordResetLink_positive_createPasswordWithDefaultExpirationTime() throws Exception {
-    var expectedLink = MOCK_FOLIO_UI_HOST + DEFAULT_UI_URL + '/' + RESET_PASSWORD_TOKEN;
+    var expectedLink = getExpectedPasswordResetLink();
+
+    callGeneratePasswordResetLink()
+      .andExpectAll(status().isOk(),
+        jsonPath("$.link", is(expectedLink)));
+
+    verify(notificationClient).sendNotification(any());
+  }
+
+  @Test
+  @WireMockStub(scripts = "/wiremock/stubs/config/get-configs-without-reset-extended.json")
+  @WireMockStub(scripts = "/wiremock/stubs/users/get-diku-user.json")
+  @WireMockStub(scripts = "/wiremock/stubs/login/reset-existing-password.json")
+  @WireMockStub(scripts = "/wiremock/stubs/notify/create-password-reset-notification.json")
+  public void shouldGenerateAndSendPasswordNotificationForTokenInQueryParams() throws Exception {
+    var expectedLink = MOCK_FOLIO_UI_HOST + DEFAULT_UI_URL
+      + "?resetToken=" + RESET_PASSWORD_TOKEN
+      + "&tenant=" + TEST_TENANT;
 
     callGeneratePasswordResetLink()
       .andExpectAll(status().isOk(),
@@ -176,7 +193,7 @@ class GeneratePasswordResetLinkIT extends BaseIntegrationTest {
   @SneakyThrows
   private void generateAndSendResetPasswordNotificationWhenPasswordExistsWith(
     String expectedExpirationTime, String expectedExpirationTimeOfUnit) {
-    var expectedLink = MOCK_FOLIO_UI_HOST + DEFAULT_UI_URL + '/' + RESET_PASSWORD_TOKEN;
+    var expectedLink = getExpectedPasswordResetLink();
 
     callGeneratePasswordResetLink()
       .andExpectAll(status().isOk(), jsonPath("$.link", is(expectedLink)));
@@ -194,6 +211,10 @@ class GeneratePasswordResetLinkIT extends BaseIntegrationTest {
       .withText(StringUtils.EMPTY);
 
     verify(notificationClient).sendNotification(eq(expectedNotification));
+  }
+
+  private static String getExpectedPasswordResetLink() {
+    return MOCK_FOLIO_UI_HOST + DEFAULT_UI_URL + '/' + RESET_PASSWORD_TOKEN + "?tenant=" + TEST_TENANT;
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/uk/it/GeneratePasswordResetLinkIT.java
+++ b/src/test/java/org/folio/uk/it/GeneratePasswordResetLinkIT.java
@@ -123,7 +123,7 @@ class GeneratePasswordResetLinkIT extends BaseIntegrationTest {
   @WireMockStub(scripts = "/wiremock/stubs/users/get-diku-user.json")
   @WireMockStub(scripts = "/wiremock/stubs/login/reset-existing-password.json")
   @WireMockStub(scripts = "/wiremock/stubs/notify/create-password-reset-notification.json")
-  public void shouldGenerateAndSendPasswordNotificationForTokenInQueryParams() throws Exception {
+  void shouldGenerateAndSendPasswordNotificationForTokenInQueryParams() throws Exception {
     var expectedLink = MOCK_FOLIO_UI_HOST + DEFAULT_UI_URL
       + "?resetToken=" + RESET_PASSWORD_TOKEN
       + "&tenant=" + TEST_TENANT;

--- a/src/test/resources/wiremock/stubs/config/get-configs-without-reset-extended.json
+++ b/src/test/resources/wiremock/stubs/config/get-configs-without-reset-extended.json
@@ -1,0 +1,38 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/configurations/entries?query=module==USERSBL",
+    "headers": {
+      "x-okapi-tenant": { "equalTo": "diku" },
+      "x-okapi-token": { "equalTo": "X-Okapi-Token test value" }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "configs": [
+        {
+          "module": "USERSBL",
+          "configName": "validation_rules",
+          "code": "FOLIO_HOST",
+          "description": "for patrons",
+          "default": true,
+          "enabled": true,
+          "value": "http://localhost:3000"
+        },
+        {
+          "module": "USERSBL",
+          "configName": "validation_rules",
+          "code": "PUT_RESET_TOKEN_IN_QUERY_PARAMS",
+          "default": true,
+          "enabled": true,
+          "value": "true"
+        }
+      ],
+      "totalRecords": 1
+    }
+  }
+}


### PR DESCRIPTION
… value

## Purpose

Move reset token to query parameters to resolve an issue with Amazon S3 and Cloud Front (URL path has a limit of 1024 characters)

## Approach

- Use `PUT_RESET_TOKEN_IN_QUERY_PARAMS` from mod-users-bl configuration to move reset token from URL path to query parameters
- Add integration test to verify token generation

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
