### PR TITLE
Group dependabot dependencies by predefined dependency types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,28 @@ updates:
       prefix: fix
       prefix-development: chore
       include: scope
+    groups:
+      dev-folio-deps:
+        patterns:
+          - "folio-*"
+        exclude-patterns:
+          - "folio-backend-testing"
+      dev-deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "folio-*"
+          - "spring*test"
+          - "awaitility"
+          - "folio-backend-testing"
+          - "*testcontainers*"
+          - "instancio*"
+          - "kryo"
+      test-deps:
+        patterns:
+          - "spring*test"
+          - "awaitility"
+          - "folio-backend-testing"
+          - "*testcontainers*"
+          - "instancio*"
+          - "kryo"


### PR DESCRIPTION
## Purpose
Group dependabot dependencies by 3 custom dependency types to avoid an avalanche of PRs per each dependency

## Approach
* add groups for folio libs/ general libs/ testing dependencies

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
