### PR TITLE
MODUSERSKC-34: add type to system user

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ After that the documentation will be available in `target/docs/mod-users-keycloa
 | Name                              | Default value                    | Required | Description                                                            |
 |:----------------------------------|:---------------------------------|:--------:|:-----------------------------------------------------------------------|
 | SYSTEM_USER_USERNAME_TEMPLATE     | {tenantId}-system-user           |  false   | System user username template, used to generate system user `username` |
-| SYSTEM_USER_EMAIL_TEMPLATE        | {tenantId}-system-user@ebsco.com |  false   | System user email template, used to generate system user `email`.      |
+| SYSTEM_USER_EMAIL_TEMPLATE        | {tenantId}-system-user@folio.org |  false   | System user email template, used to generate system user `email`.      |
 | SYSTEM_USER_ROLE                  | System                           |  false   | System user role name. It will be assigned on tenant initialization    |
 | SYSTEM_USER_PASSWORD_LENGTH       | 32                               |  false   | Batch size for user migration. Max value is 50                         |
 | SYSTEM_USER_RETRY_COUNT           | 10                               |  false   | Number of retry attempts to create a system user                       |

--- a/src/main/java/org/folio/uk/configuration/SystemUserConfigurationProperties.java
+++ b/src/main/java/org/folio/uk/configuration/SystemUserConfigurationProperties.java
@@ -31,7 +31,7 @@ public class SystemUserConfigurationProperties {
    * </ul>
    * </p>
    */
-  private String emailTemplate = "{tenantId}-system-user@ebsco.com";
+  private String emailTemplate = "{tenantId}-system-user@folio.org";
 
   /**
    * System user role name.

--- a/src/main/java/org/folio/uk/integration/keycloak/SystemUserService.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/SystemUserService.java
@@ -37,7 +37,7 @@ public class SystemUserService {
   public void create() {
     var username = generateValueByTemplate(systemUserConfiguration.getUsernameTemplate());
     var systemUserEmail = generateValueByTemplate(systemUserConfiguration.getEmailTemplate());
-    var createdSystemUser = createUser(username, "System User", systemUserEmail, "staff");
+    var createdSystemUser = createUser(username, "System User", systemUserEmail, "system");
     checkAndUpdateSystemUserRole(createdSystemUser.getUsername());
   }
 

--- a/src/main/java/org/folio/uk/integration/keycloak/SystemUserService.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/SystemUserService.java
@@ -37,7 +37,7 @@ public class SystemUserService {
   public void create() {
     var username = generateValueByTemplate(systemUserConfiguration.getUsernameTemplate());
     var systemUserEmail = generateValueByTemplate(systemUserConfiguration.getEmailTemplate());
-    var createdSystemUser = createUser(username, "System User", systemUserEmail, null);
+    var createdSystemUser = createUser(username, "System User", systemUserEmail, "staff");
     checkAndUpdateSystemUserRole(createdSystemUser.getUsername());
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,7 +66,7 @@ application:
     include-only-visible-permissions: ${INCLUDE_ONLY_VISIBLE_PERMISSIONS:true}
   system-user:
     username-template: ${SYSTEM_USER_USERNAME_TEMPLATE:{tenantId}-system-user}
-    email-template: ${SYSTEM_USER_EMAIL_TEMPLATE:{tenantId}-system-user@folio.com}
+    email-template: ${SYSTEM_USER_EMAIL_TEMPLATE:{tenantId}-system-user@folio.org}
     system-user-role: ${SYSTEM_USER_ROLE:System}
     password-length: ${SYSTEM_USER_PASSWORD_LENGTH:32}
     retry-attempts: ${SYSTEM_USER_RETRY_COUNT:10}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,7 +66,7 @@ application:
     include-only-visible-permissions: ${INCLUDE_ONLY_VISIBLE_PERMISSIONS:true}
   system-user:
     username-template: ${SYSTEM_USER_USERNAME_TEMPLATE:{tenantId}-system-user}
-    email-template: ${SYSTEM_USER_EMAIL_TEMPLATE:{tenantId}-system-user@ebsco.com}
+    email-template: ${SYSTEM_USER_EMAIL_TEMPLATE:{tenantId}-system-user@folio.com}
     system-user-role: ${SYSTEM_USER_ROLE:System}
     password-length: ${SYSTEM_USER_PASSWORD_LENGTH:32}
     retry-attempts: ${SYSTEM_USER_RETRY_COUNT:10}

--- a/src/test/java/org/folio/uk/integration/keycloak/SystemUserServiceTest.java
+++ b/src/test/java/org/folio/uk/integration/keycloak/SystemUserServiceTest.java
@@ -90,7 +90,7 @@ class SystemUserServiceTest {
 
     var capturedPassword = passwordCaptor.getValue();
     assertThat(passwordCaptor.getValue()).hasSize(userConfiguration.getPasswordLength());
-    assertThat(userCaptor.getValue()).usingRecursiveComparison().ignoringFields("id").isEqualTo(user());
+    assertThat(userCaptor.getValue()).usingRecursiveComparison().ignoringFields("id").isEqualTo(systemUser());
     assertThat(userCaptor.getValue().getId()).isNotNull();
 
     verify(secureStore).set(SYSTEM_USER_STORE_KEY, capturedPassword);
@@ -191,7 +191,7 @@ class SystemUserServiceTest {
   @Test
   void delete_positive() {
     var userId = CAPABILITY_ID;
-    var user = user().id(userId);
+    var user = systemUser().id(userId);
 
     when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
     when(userService.findUsers("username==test-system-user", 1)).thenReturn(new Users().addUsersItem(user));
@@ -227,10 +227,11 @@ class SystemUserServiceTest {
     return keycloakUser;
   }
 
-  private static User user() {
+  private static User systemUser() {
     return new User()
       .username(USERNAME)
       .active(true)
+      .type("staff")
       .personal(new Personal()
         .firstName("System User")
         .lastName(SYSTEM_ROLE)

--- a/src/test/java/org/folio/uk/integration/keycloak/SystemUserServiceTest.java
+++ b/src/test/java/org/folio/uk/integration/keycloak/SystemUserServiceTest.java
@@ -222,7 +222,7 @@ class SystemUserServiceTest {
     keycloakUser.setUserName(USERNAME);
     keycloakUser.setFirstName("Global User");
     keycloakUser.setLastName(SYSTEM_ROLE);
-    keycloakUser.setEmail("test-system-user@ebsco.com");
+    keycloakUser.setEmail("test-system-user@folio.org");
     keycloakUser.setEnabled(true);
     return keycloakUser;
   }
@@ -231,11 +231,11 @@ class SystemUserServiceTest {
     return new User()
       .username(USERNAME)
       .active(true)
-      .type("staff")
+      .type("system")
       .personal(new Personal()
         .firstName("System User")
         .lastName(SYSTEM_ROLE)
-        .email("test-system-user@ebsco.com"));
+        .email("test-system-user@folio.org"));
   }
 
   private static User moduleUser() {

--- a/src/test/java/org/folio/uk/it/UserIT.java
+++ b/src/test/java/org/folio/uk/it/UserIT.java
@@ -222,7 +222,7 @@ class UserIT extends BaseIntegrationTest {
 
   @Test
   void create_positive_keycloakOnly() throws Exception {
-    var user = TestConstants.user(UUID.randomUUID().toString(), "keycloakOnlyUser", "kc@mail.com", "nus@folio.com");
+    var user = TestConstants.user(UUID.randomUUID().toString(), "keycloakOnlyUser", "kc@mail.com", "nus@folio.org");
     var mvcResult = doPost("/users-keycloak/users?keycloakOnly=true", user).andReturn();
     var resp = parseResponse(mvcResult, User.class);
 
@@ -267,7 +267,7 @@ class UserIT extends BaseIntegrationTest {
   })
   void create_positive_kc_only_authUserExists() throws Exception {
     var userId = "d24b7b4a-00ed-416e-a810-981b003bd158";
-    var user = TestConstants.user(userId, "create-user-auth-exist", "au_exist@mail.com", "nus@folio.com");
+    var user = TestConstants.user(userId, "create-user-auth-exist", "au_exist@mail.com", "nus@folio.org");
     doPost("/users-keycloak/users?keycloakOnly=true", user);
 
     mockMvc.perform(post("/users-keycloak/users")
@@ -286,7 +286,7 @@ class UserIT extends BaseIntegrationTest {
   })
   void create_positive_authUserExists() throws Exception {
     var userId = "d24b7b4a-00ed-416e-a810-981b003bd158";
-    var user = TestConstants.user(userId, "create-user-auth-exist", "au_exist@mail.com", "nus@folio.com");
+    var user = TestConstants.user(userId, "create-user-auth-exist", "au_exist@mail.com", "nus@folio.org");
     doPost("/users-keycloak/users?keycloakOnly=false", user);
 
     mockMvc.perform(post("/users-keycloak/users")
@@ -314,7 +314,7 @@ class UserIT extends BaseIntegrationTest {
   })
   void update_positive() throws Exception {
     var userId = "202a8ef0-d07b-4626-ad41-48c2d50d9099";
-    var user = TestConstants.user(userId, "update-user", "uu@mail.com", "nus@folio.com");
+    var user = TestConstants.user(userId, "update-user", "uu@mail.com", "nus@folio.org");
     doPost("/users-keycloak/users?keycloakOnly=true", user);
     doPut("/users-keycloak/users/{id}", user, userId);
 
@@ -327,7 +327,7 @@ class UserIT extends BaseIntegrationTest {
   })
   void update_with_accept_text_positive() throws Exception {
     var userId = "202a8ef0-d07b-4626-ad41-48c2d50d9099";
-    var user = TestConstants.user(userId, "update-user", "uu@mail.com", "nus@folio.com");
+    var user = TestConstants.user(userId, "update-user", "uu@mail.com", "nus@folio.org");
     doPost("/users-keycloak/users?keycloakOnly=true", user);
 
     mockMvc.perform(put("/users-keycloak/users/{id}", userId)
@@ -343,7 +343,7 @@ class UserIT extends BaseIntegrationTest {
   @WireMockStub(scripts = "/wiremock/stubs/users/update-user-notfound.json")
   void update_negative_userNotFound() throws Exception {
     var user = TestConstants.user("f4b05750-bd6c-427b-a651-7ba2191d24a3", "update-user-notfound", "uunf@mail.com",
-      "nus@folio.com");
+      "nus@folio.org");
     attemptPut("/users-keycloak/users/{id}", user, user.getId())
       .andExpectAll(notFoundWithMsg("Not found"));
   }
@@ -365,7 +365,7 @@ class UserIT extends BaseIntegrationTest {
   })
   void update_positive_authUserNotFound() throws Exception {
     var userId = "95a4a5c0-ca68-4d26-af83-62f5c3586f18";
-    var user = TestConstants.user(userId, "update-user-no-auth", "uuna@mail.com", "nus@folio.com");
+    var user = TestConstants.user(userId, "update-user-no-auth", "uuna@mail.com", "nus@folio.org");
     attemptPut("/users-keycloak/users/{id}", user, userId)
       .andExpect(status().isNoContent());
   }
@@ -386,7 +386,7 @@ class UserIT extends BaseIntegrationTest {
   })
   void delete_positive() throws Exception {
     var user = TestConstants.user("d3958402-2f80-421b-a527-9933245a3556", "delete-user", "du@mail.com",
-      "nus@folio.com");
+      "nus@folio.org");
     doPost("/users-keycloak/users?keycloakOnly=true", user);
     doDelete("/users-keycloak/users/{id}", user.getId());
   }
@@ -415,7 +415,7 @@ class UserIT extends BaseIntegrationTest {
   })
   void delete_positive_noUser() throws Exception {
     var user = TestConstants.user("d3958402-2f80-421b-a527-9933245a3556", "delete-user", "du@mail.com",
-      "nus@folio.com");
+      "nus@folio.org");
     doPost("/users-keycloak/users?keycloakOnly=true", user);
     doDelete("/users-keycloak/users/{id}", user.getId());
   }

--- a/src/test/java/org/folio/uk/support/TestConstants.java
+++ b/src/test/java/org/folio/uk/support/TestConstants.java
@@ -33,7 +33,7 @@ public class TestConstants {
   public static final String PERMISSION = "foo.bar";
 
   public static User user() {
-    return user(USER_ID.toString(), USER_NAME, "new9@new.com", "newUser@folio.com");
+    return user(USER_ID.toString(), USER_NAME, "new9@new.com", "newUser@folio.org");
   }
 
   public static User user(String id, String username, String email, String externalSystemId) {

--- a/src/test/resources/wiremock/stubs/users/create-system-user.json
+++ b/src/test/resources/wiremock/stubs/users/create-system-user.json
@@ -28,7 +28,7 @@
       {
         "matchesJsonPath": {
           "expression": "$.personal.email",
-          "equalTo": "master-system-user@ebsco.com"
+          "equalTo": "master-system-user@folio.org"
         }
       }
     ]
@@ -45,7 +45,7 @@
       "personal": {
         "firstName": "System User",
         "lastName": "System",
-        "email": "master-system-user@ebsco.com"
+        "email": "master-system-user@folio.org"
       }
     }
   }

--- a/src/test/resources/wiremock/stubs/users/create-user-auth-exist.json
+++ b/src/test/resources/wiremock/stubs/users/create-user-auth-exist.json
@@ -15,7 +15,7 @@
     "jsonBody": {
       "username": "create-user-auth-exist",
       "id": "d24b7b4a-00ed-416e-a810-981b003bd158",
-      "externalSystemId": "nus@folio.com",
+      "externalSystemId": "nus@folio.org",
       "barcode": "12359",
       "active": true,
       "type": "",

--- a/src/test/resources/wiremock/stubs/users/create-user.json
+++ b/src/test/resources/wiremock/stubs/users/create-user.json
@@ -19,7 +19,7 @@
       "active": true,
       "type": "",
       "patronGroup": "503a81cd-6c26-400f-b620-14c08943697c",
-      "externalSystemId": "newUser@folio.com",
+      "externalSystemId": "newUser@folio.org",
       "departments": [],
       "proxyFor": [],
       "personal": {

--- a/src/test/resources/wiremock/stubs/users/find-system-user-by-id.json
+++ b/src/test/resources/wiremock/stubs/users/find-system-user-by-id.json
@@ -23,7 +23,7 @@
       "personal": {
         "firstName": "System User",
         "lastName": "System",
-        "email": "master-system-user@ebsco.com"
+        "email": "master-system-user@folio.org"
       }
     }
   }

--- a/src/test/resources/wiremock/stubs/users/find-system-user-by-query.json
+++ b/src/test/resources/wiremock/stubs/users/find-system-user-by-query.json
@@ -26,7 +26,7 @@
           "personal": {
             "firstName": "System User",
             "lastName": "System",
-            "email": "master-system-user@ebsco.com"
+            "email": "master-system-user@folio.org"
           }
         }
       ]

--- a/src/test/resources/wiremock/stubs/users/update-user-id-notmatch.json
+++ b/src/test/resources/wiremock/stubs/users/update-user-id-notmatch.json
@@ -11,7 +11,7 @@
         "equalToJson": {
           "username": "ZakirBailey",
           "id": "d3958402-2f80-421b-a527-9933245a3556",
-          "externalSystemId": "newUser@folio.com",
+          "externalSystemId": "newUser@folio.org",
           "barcode": "12359",
           "active": true,
           "patronGroup": "503a81cd-6c26-400f-b620-14c08943697c",

--- a/src/test/resources/wiremock/stubs/users/update-user-no-auth.json
+++ b/src/test/resources/wiremock/stubs/users/update-user-no-auth.json
@@ -11,7 +11,7 @@
         "equalToJson": {
           "username": "update-user-no-auth",
           "id": "95a4a5c0-ca68-4d26-af83-62f5c3586f18",
-          "externalSystemId": "nus@folio.com",
+          "externalSystemId": "nus@folio.org",
           "barcode": "12359",
           "active": true,
           "patronGroup": "503a81cd-6c26-400f-b620-14c08943697c",

--- a/src/test/resources/wiremock/stubs/users/update-user-notfound.json
+++ b/src/test/resources/wiremock/stubs/users/update-user-notfound.json
@@ -11,7 +11,7 @@
         "equalToJson": {
           "username": "update-user-notfound",
           "id": "f4b05750-bd6c-427b-a651-7ba2191d24a3",
-          "externalSystemId": "nus@folio.com",
+          "externalSystemId": "nus@folio.org",
           "barcode": "12359",
           "active": true,
           "patronGroup": "503a81cd-6c26-400f-b620-14c08943697c",

--- a/src/test/resources/wiremock/stubs/users/update-user.json
+++ b/src/test/resources/wiremock/stubs/users/update-user.json
@@ -11,7 +11,7 @@
         "equalToJson": {
           "username": "update-user",
           "id": "202a8ef0-d07b-4626-ad41-48c2d50d9099",
-          "externalSystemId": "nus@folio.com",
+          "externalSystemId": "nus@folio.org",
           "barcode": "12359",
           "active": true,
           "patronGroup": "503a81cd-6c26-400f-b620-14c08943697c",


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODUSERSKC-34
The mod-users-keycloak creates a system user with a system role while enabling the module for a tenant. The type of user is null (hardcoded). The mod-users in consortium mode requires a type of user. There is no consortium mode for the tenant when it's a fresh environment (without reference data), that is why it was working. The consortium mode turns on after the mod-consortia-keycloak is enabled for the tenant. So, consortium mode is disabled for all modules in the app-platform-minimal before the app-platform-complete, which contains the mod-consortia-keycloak, is enabled.
To fix the bug we should add the type of user for System User created while tenant enabling.


## Approach

- add system user type ('staff')
- update tests

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
