### PR TITLE
MODUSERSKC-29: add endpoint to resolve user permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -143,6 +143,11 @@
             "users.item.get",
             "login.password-reset-action.get"
           ]
+        },
+        {
+          "methods" : [ "GET" ],
+          "pathPattern" : "/users-keycloak/users/{id}/permissions",
+          "permissionsRequired" : []
         }
       ]
     },

--- a/src/main/java/org/folio/uk/controller/UserController.java
+++ b/src/main/java/org/folio/uk/controller/UserController.java
@@ -49,8 +49,8 @@ public class UserController implements UsersApi {
   }
 
   @Override
-  public ResponseEntity<PermissionsContainer> resolvePermissions(UUID userId, PermissionsContainer userPermissions) {
-    var resolvedPermissions = service.resolvePermissions(userId, userPermissions.getPermissions());
+  public ResponseEntity<PermissionsContainer> findPermissions(UUID userId, List<String> permissions) {
+    var resolvedPermissions = service.resolvePermissions(userId, permissions);
     var result = new PermissionsContainer().permissions(resolvedPermissions);
     return ResponseEntity.ok(result);
   }

--- a/src/main/java/org/folio/uk/controller/UserController.java
+++ b/src/main/java/org/folio/uk/controller/UserController.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.folio.uk.domain.dto.CompositeUser;
 import org.folio.uk.domain.dto.IncludedField;
+import org.folio.uk.domain.dto.PermissionsContainer;
 import org.folio.uk.domain.dto.User;
 import org.folio.uk.rest.resource.UsersApi;
 import org.folio.uk.service.UserService;
@@ -45,5 +46,12 @@ public class UserController implements UsersApi {
   public ResponseEntity<String> deleteUser(UUID id) {
     service.deleteUser(id);
     return ResponseEntity.status(NO_CONTENT).build();
+  }
+
+  @Override
+  public ResponseEntity<PermissionsContainer> resolvePermissions(UUID userId, PermissionsContainer userPermissions) {
+    var resolvedPermissions = service.resolvePermissions(userId, userPermissions.getPermissions());
+    var result = new PermissionsContainer().permissions(resolvedPermissions);
+    return ResponseEntity.ok(result);
   }
 }

--- a/src/main/java/org/folio/uk/integration/roles/UserPermissionsClient.java
+++ b/src/main/java/org/folio/uk/integration/roles/UserPermissionsClient.java
@@ -1,5 +1,6 @@
 package org.folio.uk.integration.roles;
 
+import java.util.List;
 import java.util.UUID;
 import org.folio.uk.integration.roles.model.UserPermissions;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -11,5 +12,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface UserPermissionsClient {
 
   @GetMapping("/users/{id}")
-  UserPermissions getPermissionsForUser(@PathVariable("id") UUID id, @RequestParam("onlyVisible") Boolean onlyVisible);
+  UserPermissions getPermissionsForUser(@PathVariable("id") UUID id, @RequestParam("onlyVisible") Boolean onlyVisible,
+    @RequestParam("desiredPermissions") List<String> desiredPermissions);
 }

--- a/src/main/java/org/folio/uk/service/UserService.java
+++ b/src/main/java/org/folio/uk/service/UserService.java
@@ -146,12 +146,6 @@ public class UserService {
     return permissions.getPermissions();
   }
 
-  private static boolean match(String s1, String s2) {
-    return s2.endsWith(".*")
-      ? s1.startsWith(s2.substring(0, s2.length() - 1))
-      : s1.equals(s2);
-  }
-
   private void removeUserWithLinkedResources(UUID id) {
     usersClient.deleteUser(id);
 

--- a/src/main/java/org/folio/uk/service/UserService.java
+++ b/src/main/java/org/folio/uk/service/UserService.java
@@ -135,19 +135,15 @@ public class UserService {
   }
 
   /**
-   * Resolves permissions for user. If user has permission with wildcard, then all permissions that match the wildcard.
-   * Example: user has permission ["users.item.get", "users.item.post", "users.collection.put"] and requested
-   * permissions are ["users.item.*"] then resolved permissions will be ["users.item.get", "users.item.post"].
+   * Resolves user permissions.
    *
    * @param userId - user id
    * @param userPermissions - list of permissions should be resolved
    * @return list of resolved permissions
    */
   public List<String> resolvePermissions(UUID userId, List<String> userPermissions) {
-    var allUserPermissions = userPermissionsClient.getPermissionsForUser(userId, false);
-    return toStream(allUserPermissions.getPermissions())
-      .filter(s1 -> toStream(userPermissions).anyMatch(s2 -> match(s1, s2)))
-      .collect(toList());
+    var permissions = userPermissionsClient.getPermissionsForUser(userId, false, userPermissions);
+    return permissions.getPermissions();
   }
 
   private static boolean match(String s1, String s2) {
@@ -222,7 +218,7 @@ public class UserService {
 
   private PermissionUser fetchPermissionUser(UUID userId) {
     var includeOnlyVisiblePermissions = rolesKeycloakConfiguration.isIncludeOnlyVisiblePermissions();
-    var userPermissions = userPermissionsClient.getPermissionsForUser(userId, includeOnlyVisiblePermissions);
+    var userPermissions = userPermissionsClient.getPermissionsForUser(userId, includeOnlyVisiblePermissions, null);
     var perms = emptyIfNull(userPermissions.getPermissions());
 
     return new PermissionUser()

--- a/src/main/resources/swagger.api/schemas/user_permissions/permissions.json
+++ b/src/main/resources/swagger.api/schemas/user_permissions/permissions.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Permissions container",
+  "properties": {
+    "permissions": {
+      "type": "array",
+      "description": "Permissions array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/main/resources/swagger.api/users-keycloak.yaml
+++ b/src/main/resources/swagger.api/users-keycloak.yaml
@@ -147,6 +147,35 @@ paths:
         '500':
           $ref: '#/components/responses/internalServerError'
 
+  /users-keycloak/users/{id}/resolve-permissions:
+    post:
+      operationId: resolvePermissions
+      description: Resolve permissions for a user. Returns permissions that are granted to the user
+      tags:
+        - users
+      parameters:
+        - $ref: '#/components/parameters/path-entity-id'
+      requestBody:
+        required: true
+        description: Permissions to resolve
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/permissionsContainer'
+      responses:
+        '200':
+          description: Returns resolved permissions for a user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/permissionsContainer'
+        '400':
+          $ref: '#/components/responses/badRequest'
+        '404':
+          $ref: '#/components/responses/entityNotFound'
+        '500':
+          $ref: '#/components/responses/internalServerError'
+
   /users-keycloak/_self:
     get:
       operationId: getUserBySelfReference
@@ -385,6 +414,8 @@ components:
       $ref: schemas/policy/policy.json
     policies:
       $ref: schemas/policy/policies.json
+    permissionsContainer:
+      $ref: schemas/user_permissions/permissions.json
 
     includedField:
       type: string

--- a/src/main/resources/swagger.api/users-keycloak.yaml
+++ b/src/main/resources/swagger.api/users-keycloak.yaml
@@ -147,21 +147,15 @@ paths:
         '500':
           $ref: '#/components/responses/internalServerError'
 
-  /users-keycloak/users/{id}/resolve-permissions:
-    post:
-      operationId: resolvePermissions
-      description: Resolve permissions for a user. Returns permissions that are granted to the user
+  /users-keycloak/users/{id}/permissions:
+    get:
+      operationId: findPermissions
+      description: Finds user permissions by filter. desiredPermissions query parameter is required. Wildcard (*) is supported.
       tags:
         - users
       parameters:
         - $ref: '#/components/parameters/path-entity-id'
-      requestBody:
-        required: true
-        description: Permissions to resolve
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/permissionsContainer'
+        - $ref: '#/components/parameters/desired-permissions'
       responses:
         '200':
           description: Returns resolved permissions for a user
@@ -527,4 +521,15 @@ components:
       schema:
         type: boolean
         default: false
+    desired-permissions:
+      in: query
+      required: true
+      name: desiredPermissions
+      description: Permissions of permission prefix to filter by
+      schema:
+        type: array
+        items:
+          type: string
+      example: [ "users.collection.get", "users.item.*" ]
+
 

--- a/src/test/java/org/folio/uk/it/UserIT.java
+++ b/src/test/java/org/folio/uk/it/UserIT.java
@@ -6,6 +6,7 @@ import static org.folio.test.TestConstants.TENANT_ID;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.folio.test.TestUtils.parseResponse;
 import static org.folio.test.TestUtils.readString;
+import static org.folio.uk.support.TestConstants.USER_ID;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -42,7 +43,7 @@ class UserIT extends BaseIntegrationTest {
   @Test
   @WireMockStub(scripts = "/wiremock/stubs/users/get-user.json")
   void get_positive() throws Exception {
-    doGet("/users-keycloak/users/{id}", TestConstants.USER_ID)
+    doGet("/users-keycloak/users/{id}", USER_ID)
       .andExpect(json("user/get-user-response.json"));
   }
 
@@ -409,7 +410,7 @@ class UserIT extends BaseIntegrationTest {
     "/wiremock/stubs/users/get-user-roles.json"
   })
   void delete_positive_noAuthUser() throws Exception {
-    doDelete("/users-keycloak/users/{id}", TestConstants.USER_ID);
+    doDelete("/users-keycloak/users/{id}", USER_ID);
   }
 
   @Test
@@ -430,7 +431,8 @@ class UserIT extends BaseIntegrationTest {
   void resolvePermissions_positive() throws Exception {
     var request = new Permissions().permissions(List.of("ui.all", "users.item.get", "inventory.collection.*"));
 
-    attemptPost("/users-keycloak/users/{id}/resolve-permissions", request, TestConstants.USER_ID)
+    attemptGet("/users-keycloak/users/{id}/permissions?desiredPermissions=ui.all&desiredPermissions=users.item.*",
+      USER_ID)
       .andExpect(status().isOk())
       .andExpect(content().json(readString("json/user/resolve-permissions.json")));
   }

--- a/src/test/java/org/folio/uk/it/UserIT.java
+++ b/src/test/java/org/folio/uk/it/UserIT.java
@@ -5,6 +5,7 @@ import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.test.TestConstants.TENANT_ID;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.folio.test.TestUtils.parseResponse;
+import static org.folio.test.TestUtils.readString;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -12,6 +13,7 @@ import static org.springframework.http.MediaType.TEXT_PLAIN;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -22,6 +24,7 @@ import org.folio.test.extensions.WireMockStub;
 import org.folio.test.types.IntegrationTest;
 import org.folio.uk.base.BaseIntegrationTest;
 import org.folio.uk.domain.dto.CompositeUser;
+import org.folio.uk.domain.dto.Permissions;
 import org.folio.uk.domain.dto.User;
 import org.folio.uk.exception.RequestValidationException;
 import org.folio.uk.support.TestConstants;
@@ -418,5 +421,17 @@ class UserIT extends BaseIntegrationTest {
       "nus@folio.org");
     doPost("/users-keycloak/users?keycloakOnly=true", user);
     doDelete("/users-keycloak/users/{id}", user.getId());
+  }
+
+  @Test
+  @WireMockStub(scripts = {
+    "/wiremock/stubs/users/get-perms-resolve-permissions.json"
+  })
+  void resolvePermissions_positive() throws Exception {
+    var request = new Permissions().permissions(List.of("ui.all", "users.item.get", "inventory.collection.*"));
+
+    attemptPost("/users-keycloak/users/{id}/resolve-permissions", request, TestConstants.USER_ID)
+      .andExpect(status().isOk())
+      .andExpect(content().json(readString("json/user/resolve-permissions.json")));
   }
 }

--- a/src/test/resources/json/user/resolve-permissions.json
+++ b/src/test/resources/json/user/resolve-permissions.json
@@ -1,7 +1,5 @@
 {
   "permissions": [
-    "ui.all",
-    "inventory.collection.get",
-    "inventory.collection.post"
+    "ui.all", "users.item.post", "users.item.get"
   ]
 }

--- a/src/test/resources/json/user/resolve-permissions.json
+++ b/src/test/resources/json/user/resolve-permissions.json
@@ -1,0 +1,7 @@
+{
+  "permissions": [
+    "ui.all",
+    "inventory.collection.get",
+    "inventory.collection.post"
+  ]
+}

--- a/src/test/resources/wiremock/stubs/users/get-perms-resolve-permissions.json
+++ b/src/test/resources/wiremock/stubs/users/get-perms-resolve-permissions.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "/permissions/users/d3958402-2f80-421b-a527-9933245a3556?onlyVisible=false",
+    "url": "/permissions/users/d3958402-2f80-421b-a527-9933245a3556?onlyVisible=false&desiredPermissions=ui.all&desiredPermissions=users.item.%2A",
     "headers": {
       "x-okapi-tenant": {
         "equalTo": "master"
@@ -16,7 +16,7 @@
     "jsonBody": {
       "userId": "d3958402-2f80-421b-a527-9933245a3556",
       "permissions": [
-        "ui.all", "users.item.post", "inventory.collection.get", "inventory.collection.post"
+        "ui.all", "users.item.post", "users.item.get"
       ]
     }
   }

--- a/src/test/resources/wiremock/stubs/users/get-perms-resolve-permissions.json
+++ b/src/test/resources/wiremock/stubs/users/get-perms-resolve-permissions.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/permissions/users/d3958402-2f80-421b-a527-9933245a3556?onlyVisible=false",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "master"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "userId": "d3958402-2f80-421b-a527-9933245a3556",
+      "permissions": [
+        "ui.all", "users.item.post", "inventory.collection.get", "inventory.collection.post"
+      ]
+    }
+  }
+}
+


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODUSERSKC-29
As part of the solution for implementing support for desiredPermissions on Eureka, we need to create a new endpoint which allows the sidecars to check if a user has specific (folio) permissions assigned to them.  

## Approach

- add a new endpoint
- add tests

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
