### PR TITLE
MODUSERSKC-48: Return response bodies for error cases

### DIFF
--- a/src/main/java/org/folio/uk/controller/ApiExceptionHandler.java
+++ b/src/main/java/org/folio/uk/controller/ApiExceptionHandler.java
@@ -143,8 +143,7 @@ public class ApiExceptionHandler {
     var errors = exception.getErrors().stream()
       .map(e -> new Error()
         .code(e.getCode())
-        .message(e.getMessage()))
-      .collect(Collectors.toList());
+        .message(e.getMessage())).toList();
 
     return ResponseEntity.status(UNPROCESSABLE_ENTITY)
       .body(new ErrorResponse().errors(errors).totalRecords(errors.size()));

--- a/src/main/java/org/folio/uk/controller/ApiExceptionHandler.java
+++ b/src/main/java/org/folio/uk/controller/ApiExceptionHandler.java
@@ -243,8 +243,8 @@ public class ApiExceptionHandler {
     return buildResponseEntity(exception, INTERNAL_SERVER_ERROR, UNKNOWN_ERROR);
   }
 
-  private static ErrorResponse buildValidationError(Exception exception, List<Parameter> parameters) {
-    return buildErrorResponse(exception, parameters, VALIDATION_ERROR);
+  private static ErrorResponse buildValidationError(RequestValidationException exception, List<Parameter> parameters) {
+    return buildErrorResponse(exception, parameters, exception.getErrorCode());
   }
 
   private static ErrorResponse buildErrorResponse(Exception exception, List<Parameter> parameters, ErrorCode code) {

--- a/src/main/java/org/folio/uk/controller/ApiExceptionHandler.java
+++ b/src/main/java/org/folio/uk/controller/ApiExceptionHandler.java
@@ -21,7 +21,6 @@ import jakarta.validation.ConstraintViolationException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.extern.log4j.Log4j2;
 import org.apache.logging.log4j.Level;
 import org.folio.cql2pgjson.exception.CQLFeatureUnsupportedException;

--- a/src/main/java/org/folio/uk/exception/RequestValidationException.java
+++ b/src/main/java/org/folio/uk/exception/RequestValidationException.java
@@ -40,4 +40,17 @@ public class RequestValidationException extends RuntimeException {
     this.errorCode = VALIDATION_ERROR;
     this.errorParameters = emptyList();
   }
+
+  /**
+   * Creates {@link RequestValidationException} object for given message.
+   *
+   * @param message - validation error message
+   * @param errorCode - an error code
+   */
+  public RequestValidationException(String message, ErrorCode errorCode) {
+    super(message);
+
+    this.errorCode = errorCode;
+    this.errorParameters = emptyList();
+  }
 }


### PR DESCRIPTION
## Purpose

Return proper response bodies for error cases on call to create Keycloak user for a Folio user - have a proper "not found" HTTP response body for 404 case when Folio user doesn't exist, and have a proper "no username" HTTP response body for 400 case when Folio user doesn't have a username.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
