### PR TITLE
MODUSERSKS-48: Proper body on 404 for GET KC user

### DIFF
--- a/src/main/java/org/folio/uk/controller/AuthUserController.java
+++ b/src/main/java/org/folio/uk/controller/AuthUserController.java
@@ -45,8 +45,9 @@ public class AuthUserController implements AuthUserApi {
   @Override
   public ResponseEntity<String> checkIfExistsAuthUserById(UUID userId) {
     var userExists = keycloakService.findKeycloakUserWithUserIdAttr(userId).isPresent();
-    return userExists
-      ? ResponseEntity.status(HttpStatus.NO_CONTENT).build()
-      : ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    if (!userExists) {
+      throw new EntityNotFoundException("Not Found");
+    }
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/org/folio/uk/controller/AuthUserController.java
+++ b/src/main/java/org/folio/uk/controller/AuthUserController.java
@@ -44,10 +44,8 @@ public class AuthUserController implements AuthUserApi {
 
   @Override
   public ResponseEntity<String> checkIfExistsAuthUserById(UUID userId) {
-    var userExists = keycloakService.findKeycloakUserWithUserIdAttr(userId).isPresent();
-    if (!userExists) {
-      throw new EntityNotFoundException("Not Found");
-    }
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    return keycloakService.findKeycloakUserWithUserIdAttr(userId)
+      .map(unused -> ResponseEntity.noContent().<String>build())
+      .orElseThrow(() -> new EntityNotFoundException("Not Found"));
   }
 }

--- a/src/test/java/org/folio/uk/it/AuthUserIT.java
+++ b/src/test/java/org/folio/uk/it/AuthUserIT.java
@@ -45,7 +45,7 @@ public class AuthUserIT extends BaseIntegrationTest {
   @Test
   void verify_negative_nonExistingKeycloakUser() throws Exception {
     mockMvc.perform(get("/users-keycloak/auth-users/d3958402-2f80-421b-a527-9933245a3556").headers(okapiHeaders())
-      .contentType(APPLICATION_JSON)).andExpectAll(status().isNotFound());
+      .contentType(APPLICATION_JSON)).andExpectAll(notFoundWithMsg("Not Found"));
   }
 
   @Test


### PR DESCRIPTION
## Purpose

Provide proper response body for verify Keycloak user existence endpoint in case user doesn't exist (404 is returned)

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
