### PR TITLE
Bump up applications-poc-tools dependencies to 1.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
     <mapstruct.version>1.6.0</mapstruct.version>
     <hypersistence-utils-hibernate-63.version>3.8.2</hypersistence-utils-hibernate-63.version>
     <swagger-annotations.version>2.2.23</swagger-annotations.version>
-    <apache-commons-lang3.version>3.14.0</apache-commons-lang3.version>
-    <apache-commons-collections4.version>4.4</apache-commons-collections4.version>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
+    <commons-collections4.version>4.4</commons-collections4.version>
     <openapi-tools.jackson-databind-nullable.version>0.2.6</openapi-tools.jackson-databind-nullable.version>
     <folio-spring-support.version>8.1.2</folio-spring-support.version>
     <folio-java-checkstyle.version>1.0.1</folio-java-checkstyle.version>
-    <application-poc-tools.version>1.5.5</application-poc-tools.version>
+    <application-poc-tools.version>1.5.6</application-poc-tools.version>
     <coffee-boots.version>4.0.0</coffee-boots.version>
     <org.json.version>20240303</org.json.version>
 
@@ -132,20 +132,14 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>${apache-commons-lang3.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-      <version>${apache-commons-collections4.version}</version>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-secret-store-starter</artifactId>
+      <version>${application-poc-tools.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.folio</groupId>
-      <artifactId>folio-secret-store-starter</artifactId>
+      <artifactId>folio-tls-utils</artifactId>
       <version>${application-poc-tools.version}</version>
     </dependency>
 

--- a/src/main/java/org/folio/uk/integration/keycloak/config/KeycloakFeignClientConfig.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/config/KeycloakFeignClientConfig.java
@@ -2,7 +2,7 @@ package org.folio.uk.integration.keycloak.config;
 
 import feign.Client;
 import lombok.extern.log4j.Log4j2;
-import org.folio.common.utils.FeignClientTlsUtils;
+import org.folio.common.utils.tls.FeignClientTlsUtils;
 import org.springframework.context.annotation.Bean;
 
 @Log4j2

--- a/src/test/java/org/folio/uk/it/DisableHostnameVerificationConfig.java
+++ b/src/test/java/org/folio/uk/it/DisableHostnameVerificationConfig.java
@@ -1,0 +1,13 @@
+package org.folio.uk.it;
+
+import static org.apache.commons.lang3.SystemProperties.JDK_INTERNAL_HTTP_CLIENT_DISABLE_HOST_NAME_VERIFICATION;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DisableHostnameVerificationConfig {
+
+  static {
+    System.setProperty(JDK_INTERNAL_HTTP_CLIENT_DISABLE_HOST_NAME_VERIFICATION, "true");
+  }
+}


### PR DESCRIPTION
## Purpose
Bump up applications-poc-tools dependencies to 1.5.6 to support Hostname Verification for TLS connections
