### PR TITLE
MODPERMS-233: Rename permission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -61,7 +61,7 @@
           "permissionsRequired": [ "users-keycloak.migrations.post" ],
           "modulePermissions": [
             "users.collection.get",
-            "perms.users"
+            "perms.users.all"
           ]
         },
         {


### PR DESCRIPTION
mod-permissions renames the permission name from
perms.permissions to perms.permissions.all.

## Purpose
Update the permission name made in mod-permissions.

## Approach
Change the module descriptor.

## Merge
DO NOT MERGE alone. Merge together with https://github.com/folio-org/mod-permissions/pull/212