### PR TITLE
MODUSERSKC-63: Backwards-compatible API for expand permissions parameter

### DIFF
--- a/src/main/resources/swagger.api/schemas/permissionUser.json
+++ b/src/main/resources/swagger.api/schemas/permissionUser.json
@@ -15,7 +15,7 @@
       "type": "array",
       "description": "Permissions array",
       "items": {
-        "type": "string"
+        "type": "object"
       }
     },
     "metadata" : {


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODUSERSKC-63

Support for expand permission parameter providing backwards-compatible API response format.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
