### PR TITLE
MODUSERSKC-68 - Add feature flag for setting default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ After that the documentation will be available in `target/docs/mod-users-keycloa
 | KC_CONFIG_TTL                    | 3600s                      |  false   | Client credentials expiration timeout                                                                                                |
 | KC_LOGIN_CLIENT_SUFFIX           | -login-application         |  false   | Suffix of a Keycloak client who owns the authorization resources. It is used as `audience` for keycloak when evaluating permissions. |
 | MIGRATION_BATCH_SIZE             | 20                         |  false   | Batch size for user migration. Max value is 50                                                                                       |
+| DEFAULT_PASSWORDS_ON_MIGRATION   | false                      |  false   | If specified to true migrated user’s password being set to their username otherwise migrated users not having any credentials set    |
 | INCLUDE_ONLY_VISIBLE_PERMISSIONS | true                       |  false   | Defines if onlyVisible (UI permisisons/permission-set names) will be returned using `_self` endpoint                                 |
 
 ### Kafka environment variables

--- a/src/main/java/org/folio/uk/migration/UserMigrationService.java
+++ b/src/main/java/org/folio/uk/migration/UserMigrationService.java
@@ -54,7 +54,7 @@ public class UserMigrationService {
   private final PermissionService permissionService;
   private final UserMigrationProperties migrationProperties;
   private final UserMigrationJobRepository repository;
-  private final KeycloakService userService;
+  private final KeycloakService keycloakService;
   private final UsersClient usersClient;
   private final UserMigrationMapper mapper;
   private final FolioExecutionContext folioContext;
@@ -180,7 +180,7 @@ public class UserMigrationService {
   private Optional<User> createUserInKeycloakSafe(User user, boolean retryIfEmailNotValid) {
     var password = migrationProperties.isDefaultPasswordsOnMigration() ? user.getUsername() : null;
     try {
-      userService.createUserForMigration(user, password, fetchUserTenants(user.getId()));
+      keycloakService.createUserForMigration(user, password, fetchUserTenants(user.getId()));
       return of(user);
     } catch (Exception e) {
       var message = e.getCause().getMessage();

--- a/src/main/java/org/folio/uk/migration/UserMigrationService.java
+++ b/src/main/java/org/folio/uk/migration/UserMigrationService.java
@@ -166,7 +166,8 @@ public class UserMigrationService {
   }
 
   /**
-   * Creates a user in Keycloak, with the given user object and sets the user's password to their username.
+   * Creates a user in Keycloak, with the given user object and sets the user's password to their username
+   * if migration.default-passwords-on-migration property is set to true.
    * If the creation fails, the method will log a warning and return an empty Optional.
    * If the creation fails due to an invalid email, the method will try to create the user without an email and retry
    * once if "retryIfEmailNotValid" is set to true.
@@ -177,7 +178,7 @@ public class UserMigrationService {
    * @return an Optional of the created user object if the creation is successful, otherwise an empty Optional
    */
   private Optional<User> createUserInKeycloakSafe(User user, boolean retryIfEmailNotValid) {
-    var password = user.getUsername();
+    var password = migrationProperties.isDefaultPasswordsOnMigration() ? user.getUsername() : null;
     try {
       userService.createUserForMigration(user, password, fetchUserTenants(user.getId()));
       return of(user);

--- a/src/main/java/org/folio/uk/migration/properties/UserMigrationProperties.java
+++ b/src/main/java/org/folio/uk/migration/properties/UserMigrationProperties.java
@@ -16,4 +16,5 @@ public class UserMigrationProperties {
   @NotNull
   @Max(value = 50)
   private Integer batchSize;
+  private boolean defaultPasswordsOnMigration;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,6 +101,7 @@ application:
       truststore-file-path: ${SECRET_STORE_VAULT_TRUSTSTORE_FILE_PATH:}
   migration:
     batch-size: ${MIGRATION_BATCH_SIZE:20}
+    default-passwords-on-migration: ${DEFAULT_PASSWORDS_ON_MIGRATION:false}
   kafka:
     listener:
       system-user:

--- a/src/test/java/org/folio/uk/it/UserMigrationIT.java
+++ b/src/test/java/org/folio/uk/it/UserMigrationIT.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 
 @IntegrationTest
@@ -35,8 +35,8 @@ class UserMigrationIT extends BaseIntegrationTest {
 
   private static final String JOB_ID = "9971c946-c449-46b6-968b-77b66280b044";
 
-  @SpyBean private KeycloakService keycloakService;
-  @SpyBean private UserMigrationProperties userMigrationProperties;
+  @MockitoSpyBean private KeycloakService keycloakService;
+  @MockitoSpyBean private UserMigrationProperties userMigrationProperties;
 
   @BeforeAll
   static void beforeAll() {

--- a/src/test/java/org/folio/uk/it/UserMigrationIT.java
+++ b/src/test/java/org/folio/uk/it/UserMigrationIT.java
@@ -35,7 +35,7 @@ class UserMigrationIT extends BaseIntegrationTest {
 
   private static final String JOB_ID = "9971c946-c449-46b6-968b-77b66280b044";
 
-  @SpyBean private KeycloakService userService;
+  @SpyBean private KeycloakService keycloakService;
   @SpyBean private UserMigrationProperties userMigrationProperties;
 
   @BeforeAll
@@ -72,7 +72,7 @@ class UserMigrationIT extends BaseIntegrationTest {
     var migratedUser = users.getUsers().get(0);
 
     var passwordCaptor = ArgumentCaptor.forClass(String.class);
-    verify(userService).createUserForMigration(any(), passwordCaptor.capture(), any());
+    verify(keycloakService).createUserForMigration(any(), passwordCaptor.capture(), any());
     assertThat(passwordCaptor.getValue()).isNull();
 
     verifyKeyCloakUser(migratedUser);
@@ -103,7 +103,7 @@ class UserMigrationIT extends BaseIntegrationTest {
     var migratedUser = users.getUsers().get(0);
 
     var passwordCaptor = ArgumentCaptor.forClass(String.class);
-    verify(userService).createUserForMigration(any(), passwordCaptor.capture(), any());
+    verify(keycloakService).createUserForMigration(any(), passwordCaptor.capture(), any());
     assertThat(passwordCaptor.getValue()).isEqualTo(migratedUser.getUsername());
 
     verifyKeyCloakUser(migratedUser);


### PR DESCRIPTION
## Purpose

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->
[MODUSERSKC-68](https://folio-org.atlassian.net/browse/MODUSERSKC-68) - Add feature flag for setting default credentials
## Approach

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Put the “default” password logic behind a new feature flag. This feature should be off/disabled by default, meaning authUser credentials should not be set by the migration API.
## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
