### PR TITLE
Moduserskc 78: PUB-SUB workaround for Eureka approach

### DIFF
--- a/src/main/java/org/folio/uk/integration/keycloak/SystemUserService.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/SystemUserService.java
@@ -56,7 +56,7 @@ public class SystemUserService {
     if (isEmpty(permissions)) {
       return;
     }
-    assignCapabilities(user, permissions);
+    reAssignCapabilities(user, permissions);
   }
 
   public void updateOnEvent(SystemUserEvent event) {
@@ -65,7 +65,7 @@ public class SystemUserService {
     }
     String username = event.getName();
     findUserByUsername(username).ifPresentOrElse(
-      user -> assignCapabilities(user, event.getPermissions()), () -> createOnEvent(event));
+      user -> reAssignCapabilities(user, event.getPermissions()), () -> createOnEvent(event));
   }
 
   public void deleteOnEvent(SystemUserEvent event) {
@@ -89,6 +89,11 @@ public class SystemUserService {
     }
     log.debug("User not found by username: {}", username);
     return Optional.empty();
+  }
+
+  private void reAssignCapabilities(User user, Set<String> permissions) {
+    capabilitiesService.unassignAll(user.getId());
+    capabilitiesService.assignCapabilitiesByPermissions(user, permissions);
   }
 
   private void assignCapabilities(User user, Set<String> permissions) {

--- a/src/main/java/org/folio/uk/service/UserService.java
+++ b/src/main/java/org/folio/uk/service/UserService.java
@@ -73,6 +73,7 @@ public class UserService {
   private final FolioExecutionContext folioExecutionContext;
   private final RolesKeycloakConfigurationProperties rolesKeycloakConfiguration;
   private final KeycloakFederatedAuthProperties keycloakFederatedAuthProperties;
+  private final CapabilitiesService capabilitiesService;
 
   public User createUser(User user, boolean keycloakOnly) {
     return createUser(user, null, keycloakOnly);
@@ -195,29 +196,7 @@ public class UserService {
 
   private void removeUserWithLinkedResources(UUID id) {
     usersClient.deleteUser(id);
-
-    userCapabilitySetClient.findUserCapabilitySet(id)
-      .ifPresent(userCapabilitySet -> {
-        if (userCapabilitySet.getTotalRecords() > 0) {
-          userCapabilitySetClient.deleteUserCapabilitySet(id);
-        }
-      });
-
-    userCapabilitiesClient.findUserCapabilities(id)
-      .ifPresent(userCapabilities -> {
-        if (userCapabilities.getTotalRecords() > 0) {
-          userCapabilitiesClient.deleteUserCapabilities(id);
-        }
-      });
-
-    userRolesClient.findUserRoles(id)
-      .ifPresent(roles -> {
-        if (roles.getTotalRecords() > 0) {
-          userRolesClient.deleteUserRoles(id);
-        }
-      });
-
-    policyService.removePolicyByUserId(id);
+    capabilitiesService.unassignAll(id);
   }
 
   private Optional<UUID> findUserIdKcAttribute(User user) {

--- a/src/test/java/org/folio/uk/it/SystemUserIT.java
+++ b/src/test/java/org/folio/uk/it/SystemUserIT.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.folio.test.extensions.impl.KeycloakContainerExtension.getKeycloakAdminClient;
 import static org.folio.uk.support.TestConstants.TENANT_NAME;
-import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
 
 import java.util.UUID;
@@ -77,7 +76,11 @@ class SystemUserIT extends BaseIntegrationTest {
   @WireMockStub(scripts = {
     "/wiremock/stubs/users/find-module-system-user-by-query.json",
     "/wiremock/stubs/capabilities/query-capabilities-by-permissions.json",
-    "/wiremock/stubs/capabilities/assign-module-system-user-capabilities.json"
+    "/wiremock/stubs/capabilities/assign-module-system-user-capabilities.json",
+    "/wiremock/stubs/capabilities/query-capability-sets-by-user.json",
+    "/wiremock/stubs/capabilities/query-capabilities-by-user.json",
+    "/wiremock/stubs/policy/find-policy-by-username-empty.json",
+    "/wiremock/stubs/roles/query-roles-by-user.json"
   })
   void updateOnEvent() {
     kafkaTemplate.send(FOLIO_SYSTEM_USER_TOPIC, TestConstants.systemUserResourceUpdateEvent());
@@ -86,14 +89,18 @@ class SystemUserIT extends BaseIntegrationTest {
       .addCapabilityIdsItem(CAPABILITY_ID1);
 
     await().atMost(Durations.FIVE_SECONDS).untilAsserted(() ->
-      verify(userCapabilitiesClient, only()).assignUserCapabilities(USER_ID, expectedRequest));
+      verify(userCapabilitiesClient).assignUserCapabilities(USER_ID, expectedRequest));
   }
 
   @Test
   @WireMockStub(scripts = {
     "/wiremock/stubs/users/create-module-system-user.json",
     "/wiremock/stubs/capabilities/query-capabilities-by-permission.json",
-    "/wiremock/stubs/capabilities/assign-module-system-user-capability.json"
+    "/wiremock/stubs/capabilities/assign-module-system-user-capability.json",
+    "/wiremock/stubs/capabilities/query-capability-sets-by-user.json",
+    "/wiremock/stubs/capabilities/query-capabilities-by-user.json",
+    "/wiremock/stubs/policy/find-policy-by-username-empty.json",
+    "/wiremock/stubs/roles/query-roles-by-user.json"
   })
   void createOnEvent() {
     kafkaTemplate.send(FOLIO_SYSTEM_USER_TOPIC, TestConstants.systemUserResourceEvent());
@@ -101,7 +108,7 @@ class SystemUserIT extends BaseIntegrationTest {
     var expectedRequest = new UserCapabilitiesRequest().userId(USER_ID).addCapabilityIdsItem(CAPABILITY_ID);
 
     await().atMost(Durations.FIVE_SECONDS).untilAsserted(() ->
-      verify(userCapabilitiesClient, only()).assignUserCapabilities(USER_ID, expectedRequest)
+      verify(userCapabilitiesClient).assignUserCapabilities(USER_ID, expectedRequest)
     );
 
     var authToken = tokenService.issueToken();

--- a/src/test/java/org/folio/uk/service/CapabilitiesServiceTest.java
+++ b/src/test/java/org/folio/uk/service/CapabilitiesServiceTest.java
@@ -34,8 +34,11 @@ import org.folio.uk.domain.dto.Error;
 import org.folio.uk.domain.dto.ErrorResponse;
 import org.folio.uk.domain.dto.User;
 import org.folio.uk.domain.dto.UserCapabilitiesRequest;
+import org.folio.uk.integration.policy.PolicyService;
 import org.folio.uk.integration.roles.CapabilitiesClient;
 import org.folio.uk.integration.roles.UserCapabilitiesClient;
+import org.folio.uk.integration.roles.UserCapabilitySetClient;
+import org.folio.uk.integration.roles.UserRolesClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -57,6 +60,9 @@ class CapabilitiesServiceTest {
 
   @MockBean private CapabilitiesClient capabilitiesClient;
   @MockBean private UserCapabilitiesClient userCapabilitiesClient;
+  @MockBean private UserCapabilitySetClient userCapabilitySetClient;
+  @MockBean private UserRolesClient userRolesClient;
+  @MockBean private PolicyService policyService;
   @MockBean private ObjectMapper objectMapper;
 
   @AfterEach

--- a/src/test/java/org/folio/uk/service/UserServiceTest.java
+++ b/src/test/java/org/folio/uk/service/UserServiceTest.java
@@ -83,6 +83,7 @@ class UserServiceTest {
   @MockitoBean private FolioModuleMetadata folioModuleMetadata;
   @MockitoBean private FolioExecutionContext folioExecutionContext;
   @MockitoBean private KeycloakFederatedAuthProperties keycloakFederatedAuthProperties;
+  @MockitoBean private CapabilitiesService capabilitiesService;
 
   @AfterEach
   void tearDown() {
@@ -217,10 +218,7 @@ class UserServiceTest {
     verify(usersClient).lookupUserById(userId);
     verify(usersClient).deleteUser(userId);
     verify(keycloakService).deleteUser(userId);
-    verify(userRolesClient).deleteUserRoles(userId);
-    verify(userCapabilitySetClient).deleteUserCapabilitySet(userId);
-    verify(userCapabilitiesClient).deleteUserCapabilities(userId);
-    verify(policyService).removePolicyByUserId(userId);
+    verify(capabilitiesService).unassignAll(userId);
   }
 
   @Test
@@ -249,7 +247,7 @@ class UserServiceTest {
     verify(userRolesClient, times(0)).deleteUserRoles(userId);
     verify(userCapabilitySetClient, times(0)).deleteUserCapabilitySet(userId);
     verify(userCapabilitiesClient, times(0)).deleteUserCapabilities(userId);
-    verify(policyService).removePolicyByUserId(userId);
+    verify(capabilitiesService).unassignAll(userId);
   }
 
   @Test
@@ -287,10 +285,7 @@ class UserServiceTest {
 
     verify(usersClient).deleteUser(userId);
     verify(keycloakService).deleteUser(userId);
-    verify(userRolesClient).deleteUserRoles(userId);
-    verify(userCapabilitySetClient).deleteUserCapabilitySet(userId);
-    verify(userCapabilitiesClient).deleteUserCapabilities(userId);
-    verify(policyService).removePolicyByUserId(userId);
+    verify(capabilitiesService).unassignAll(userId);
   }
 
   @Test

--- a/src/test/resources/wiremock/stubs/capabilities/query-capabilities-by-user.json
+++ b/src/test/resources/wiremock/stubs/capabilities/query-capabilities-by-user.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/users/.*/capability-sets",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "testtenant"
+      }
+    }
+  },
+  "response": {
+    "status": 201,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "totalRecords": 0
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/capabilities/query-capability-sets-by-user.json
+++ b/src/test/resources/wiremock/stubs/capabilities/query-capability-sets-by-user.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/users/.*/capabilities",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "testtenant"
+      }
+    }
+  },
+  "response": {
+    "status": 201,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "totalRecords": 0
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/policy/find-policy-by-username-empty.json
+++ b/src/test/resources/wiremock/stubs/policy/find-policy-by-username-empty.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/policies",
+    "headers": {
+      "x-okapi-tenant": { "equalTo": "testtenant" }
+    },
+    "queryParameters": {
+      "query": { "equalTo": "name=*de5bb75d-e696-4d43-9df8-289f39367079" },
+      "limit": { "equalTo": "9999" },
+      "offset": { "equalTo": "0" }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "policies": [],
+      "totalRecords": 0
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/roles/query-roles-by-user.json
+++ b/src/test/resources/wiremock/stubs/roles/query-roles-by-user.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/roles/users/.*",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "testtenant"
+      }
+    }
+  },
+  "response": {
+    "status": 201,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "totalRecords": 0
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
The current approach for mod-pubsub and related modules (e.g. mod-audit, etc.) involves mod-pubsub defining a generic permission like pubsub.events.post which is then referenced in module descriptors for modules consuming messages from mod-pubsub.  Here this permission is used to protect endpoints meant to be invoked by mod-pubsub.  This violates two of the rules which Eureka has:

You cannot protect an endpoint with a permission defined by another module

Permissions must be unique.  IOW you can’t have two modules which specify the same permission.

To get around this issue we’re relaxing #2 and adjusting code in mod-roles-keycloak to reconcile the situation, i.e. allow for placeholder capabilities which do not protect an endpoint in the module descriptor where they’re defined, then later update the capability and create the necessary keycloak entities as needed when a module is enabled which uses that permission to protect an endpoint.

To cover case when system users already created - we should reaassign capalities to these users

[MODUSERSKC-78](https://folio-org.atlassian.net/browse/MODUSERSKC-78)

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach
- reassign capabilities for system users during the entitlement create or update

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
