### PR TITLE
[MODCONSKC-73] Implement possibility for user to login with updated username

### DIFF
--- a/src/main/java/org/folio/uk/integration/keycloak/KeycloakService.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/KeycloakService.java
@@ -75,8 +75,9 @@ public class KeycloakService {
   public void linkIdentityProviderToUser(User user, String kcUserId) {
     applyIdentityProviderOnUser(user, kcUserId, dto -> {
       if (isIdentityProviderAlreadyLinked(kcUserId, dto.tenant(), dto.providerAlias())) {
-        log.info("linkIdentityProviderToUser: Updating an existing identity provider already for user [userId: {}, kcUserId: {}, " +
-          "tenant: {}, memberTenant: {}, providerAlias: {}]", dto.userId(), kcUserId, dto.tenant(), dto.memberTenant(), dto.providerAlias());
+        log.info("linkIdentityProviderToUser: Updating an existing identity provider already for user [userId: {}, "
+          + "kcUserId: {}, tenant: {}, memberTenant: {}, providerAlias: {}]", dto.userId(), kcUserId, dto.tenant(),
+          dto.memberTenant(), dto.providerAlias());
         unlinkIdentityProviderFromUser(dto, kcUserId);
         return;
       }

--- a/src/main/java/org/folio/uk/integration/keycloak/KeycloakService.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/KeycloakService.java
@@ -75,11 +75,10 @@ public class KeycloakService {
   public void linkIdentityProviderToUser(User user, String kcUserId) {
     applyIdentityProviderOnUser(user, kcUserId, dto -> {
       if (isIdentityProviderAlreadyLinked(kcUserId, dto.tenant(), dto.providerAlias())) {
-        log.info("linkIdentityProviderToUser: Updating an existing identity provider already for user [userId: {}, "
+        log.info("linkIdentityProviderToUser: Updating an existing identity provider link for user [userId: {}, "
           + "kcUserId: {}, tenant: {}, memberTenant: {}, providerAlias: {}]", dto.userId(), kcUserId, dto.tenant(),
           dto.memberTenant(), dto.providerAlias());
         unlinkIdentityProviderFromUser(dto, kcUserId);
-        return;
       }
 
       var federatedIdentity = createFederatedIdentity(user);

--- a/src/main/java/org/folio/uk/integration/keycloak/KeycloakService.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/KeycloakService.java
@@ -75,9 +75,9 @@ public class KeycloakService {
   public void linkIdentityProviderToUser(User user, String kcUserId) {
     applyIdentityProviderOnUser(user, kcUserId, dto -> {
       if (isIdentityProviderAlreadyLinked(kcUserId, dto.tenant(), dto.providerAlias())) {
-        log.warn("Identity provider is already linked to user [userId: {}, kcUserId: {}, tenant: {}, "
-          + "memberTenant: {}, providerAlias: {}]", dto.userId(), kcUserId, dto.tenant(), dto.memberTenant(),
-          dto.providerAlias());
+        log.info("linkIdentityProviderToUser: Updating an existing identity provider already for user [userId: {}, kcUserId: {}, " +
+          "tenant: {}, memberTenant: {}, providerAlias: {}]", dto.userId(), kcUserId, dto.tenant(), dto.memberTenant(), dto.providerAlias());
+        unlinkIdentityProviderFromUser(dto, kcUserId);
         return;
       }
 
@@ -92,11 +92,15 @@ public class KeycloakService {
   }
 
   public void unlinkIdentityProviderFromUser(User user, String kcUserId) {
-    applyIdentityProviderOnUser(user, kcUserId, dto -> callKeycloak(
+    applyIdentityProviderOnUser(user, kcUserId, dto -> unlinkIdentityProviderFromUser(dto, kcUserId));
+  }
+
+  private void unlinkIdentityProviderFromUser(KeycloakIdentityProviderDto dto, String kcUserId) {
+    callKeycloak(
       () -> keycloakClient.unlinkIdentityProviderFromUser(dto.tenant(), kcUserId, dto.providerAlias(), getToken()),
       () -> String.format("Failed to unlink identity provider from user [userId: %s, kcUserId: %s, tenant: %s, "
         + "memberTenant: %s, providerAlias: %s]", dto.userId(), kcUserId, dto.tenant(), dto.memberTenant(),
-        dto.providerAlias())));
+        dto.providerAlias()));
   }
 
   private void applyIdentityProviderOnUser(User user, String kcUserId,

--- a/src/test/java/org/folio/uk/service/UserServiceIdentityProviderTest.java
+++ b/src/test/java/org/folio/uk/service/UserServiceIdentityProviderTest.java
@@ -166,7 +166,9 @@ class UserServiceIdentityProviderTest {
     var user = createShadowUser(Map.of(ORIGINAL_TENANT_ID_CUSTOM_FIELD, TENANT_NAME));
     keycloakService.linkIdentityProviderToUser(user, KC_USER_ID);
 
-    verify(keycloakClient, never()).linkIdentityProviderToUser(eq(CENTRAL_TENANT_NAME), eq(KC_USER_ID),
+    verify(keycloakClient, atMostOnce()).unlinkIdentityProviderFromUser(eq(CENTRAL_TENANT_NAME), eq(KC_USER_ID),
+      eq(PROVIDER_ALIAS), eq(AUTH_TOKEN));
+    verify(keycloakClient, atMostOnce()).linkIdentityProviderToUser(eq(CENTRAL_TENANT_NAME), eq(KC_USER_ID),
       eq(PROVIDER_ALIAS), any(FederatedIdentity.class), eq(AUTH_TOKEN));
   }
 

--- a/src/test/java/org/folio/uk/service/UserServiceIdentityProviderTest.java
+++ b/src/test/java/org/folio/uk/service/UserServiceIdentityProviderTest.java
@@ -166,8 +166,8 @@ class UserServiceIdentityProviderTest {
     var user = createShadowUser(Map.of(ORIGINAL_TENANT_ID_CUSTOM_FIELD, TENANT_NAME));
     keycloakService.linkIdentityProviderToUser(user, KC_USER_ID);
 
-    verify(keycloakClient, atMostOnce()).unlinkIdentityProviderFromUser(eq(CENTRAL_TENANT_NAME), eq(KC_USER_ID),
-      eq(PROVIDER_ALIAS), eq(AUTH_TOKEN));
+    verify(keycloakClient, atMostOnce()).unlinkIdentityProviderFromUser(CENTRAL_TENANT_NAME, KC_USER_ID,
+      PROVIDER_ALIAS, AUTH_TOKEN);
     verify(keycloakClient, atMostOnce()).linkIdentityProviderToUser(eq(CENTRAL_TENANT_NAME), eq(KC_USER_ID),
       eq(PROVIDER_ALIAS), any(FederatedIdentity.class), eq(AUTH_TOKEN));
   }


### PR DESCRIPTION
## Purpose
[[MODCONSKC-73] Implement possibility for user to login with updated username](https://folio-org.atlassian.net/browse/MODCONSKC-73)

## Approach
Modify existing idp migration logic to recreate user's link if one already exists, so that the current username is used for linking