### PR TITLE
Prepare for release 3.0.1 for Sunflower

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 ### Changes:
 ---
 
+## Version `v3.0.1` (31.03.2025)
+### Changes:
+* Implement possibility for user to login with updated username (MODCONSKC-7)
+---
+
 ## Version `v3.0.0` (14.03.2025)
 ### Changes:
 * PUB-SUB workaround for Eureka approach (MODUSERSKC-78)

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <name>mod-users-keycloak</name>
   <groupId>org.folio</groupId>
   <artifactId>mod-users-keycloak</artifactId>
-  <version>3.0.1</version>
+  <version>3.0.2-SNAPSHOT</version>
   <description>mod-users-keycloak</description>
   <packaging>jar</packaging>
 
@@ -624,7 +624,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v3.0.1</tag>
+    <tag>v3.0.0</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <name>mod-users-keycloak</name>
   <groupId>org.folio</groupId>
   <artifactId>mod-users-keycloak</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
+  <version>3.0.1</version>
   <description>mod-users-keycloak</description>
   <packaging>jar</packaging>
 
@@ -624,7 +624,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v3.0.0</tag>
+    <tag>v3.0.1</tag>
   </scm>
 
   <repositories>

--- a/src/main/java/org/folio/uk/integration/keycloak/KeycloakService.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/KeycloakService.java
@@ -75,10 +75,10 @@ public class KeycloakService {
   public void linkIdentityProviderToUser(User user, String kcUserId) {
     applyIdentityProviderOnUser(user, kcUserId, dto -> {
       if (isIdentityProviderAlreadyLinked(kcUserId, dto.tenant(), dto.providerAlias())) {
-        log.warn("Identity provider is already linked to user [userId: {}, kcUserId: {}, tenant: {}, "
-          + "memberTenant: {}, providerAlias: {}]", dto.userId(), kcUserId, dto.tenant(), dto.memberTenant(),
-          dto.providerAlias());
-        return;
+        log.info("linkIdentityProviderToUser: Updating an existing identity provider link for user [userId: {}, "
+          + "kcUserId: {}, tenant: {}, memberTenant: {}, providerAlias: {}]", dto.userId(), kcUserId, dto.tenant(),
+          dto.memberTenant(), dto.providerAlias());
+        unlinkIdentityProviderFromUser(dto, kcUserId);
       }
 
       var federatedIdentity = createFederatedIdentity(user);
@@ -92,11 +92,15 @@ public class KeycloakService {
   }
 
   public void unlinkIdentityProviderFromUser(User user, String kcUserId) {
-    applyIdentityProviderOnUser(user, kcUserId, dto -> callKeycloak(
+    applyIdentityProviderOnUser(user, kcUserId, dto -> unlinkIdentityProviderFromUser(dto, kcUserId));
+  }
+
+  private void unlinkIdentityProviderFromUser(KeycloakIdentityProviderDto dto, String kcUserId) {
+    callKeycloak(
       () -> keycloakClient.unlinkIdentityProviderFromUser(dto.tenant(), kcUserId, dto.providerAlias(), getToken()),
       () -> String.format("Failed to unlink identity provider from user [userId: %s, kcUserId: %s, tenant: %s, "
         + "memberTenant: %s, providerAlias: %s]", dto.userId(), kcUserId, dto.tenant(), dto.memberTenant(),
-        dto.providerAlias())));
+        dto.providerAlias()));
   }
 
   private void applyIdentityProviderOnUser(User user, String kcUserId,

--- a/src/test/java/org/folio/uk/service/UserServiceIdentityProviderTest.java
+++ b/src/test/java/org/folio/uk/service/UserServiceIdentityProviderTest.java
@@ -166,7 +166,9 @@ class UserServiceIdentityProviderTest {
     var user = createShadowUser(Map.of(ORIGINAL_TENANT_ID_CUSTOM_FIELD, TENANT_NAME));
     keycloakService.linkIdentityProviderToUser(user, KC_USER_ID);
 
-    verify(keycloakClient, never()).linkIdentityProviderToUser(eq(CENTRAL_TENANT_NAME), eq(KC_USER_ID),
+    verify(keycloakClient, atMostOnce()).unlinkIdentityProviderFromUser(CENTRAL_TENANT_NAME, KC_USER_ID,
+      PROVIDER_ALIAS, AUTH_TOKEN);
+    verify(keycloakClient, atMostOnce()).linkIdentityProviderToUser(eq(CENTRAL_TENANT_NAME), eq(KC_USER_ID),
       eq(PROVIDER_ALIAS), any(FederatedIdentity.class), eq(AUTH_TOKEN));
   }
 


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODCONSKC-73. Add support changes to recreated Identity provider links to be abe to login after changing username.
Release tgis change to Sunflower Bugfest.

### **Approach**
Recreate Keycloak Identity Provider links if exists that should point to new username.
Note: Login after changing username is possible now is changing username using API call intead of UI call, because UI caurrently pointed to mod-users instead of mod-users-keycloak.

