### PR TITLE
MODUSERSKC-94 Add missing fields for user

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 * Mask special CQL characters in user queries ([https://folio-org.atlassian.net/browse/MODUSERSKC-86](MODUSERSKC-86))
 * Search users in all tenants when using "Forgot password" and "Forgot username" links ([https://folio-org.atlassian.net/browse/MODUSERSKC-83](MODUSERSKC-83))
 * Default loadable roles for system users (MODUSERSKC-93)
-* Introduce configuration for FSSP (APPPOCTOOL-59) 
+* Introduce configuration for FSSP (APPPOCTOOL-59)
+* Add missing fields to user DTO ([https://folio-org.atlassian.net/browse/MODUSERSKC-94](MODUSERSKC-94))
 ---
 
 ## Version `v3.0.0` (14.03.2025)

--- a/src/main/resources/swagger.api/schemas/personal.json
+++ b/src/main/resources/swagger.api/schemas/personal.json
@@ -24,6 +24,11 @@
       "description": "The user's email address",
       "type": "string"
     },
+    "pronouns": {
+      "description": "The user's pronouns",
+      "type": "string",
+      "maxLength": 300
+    },
     "phone": {
       "description": "The user's primary phone number",
       "type": "string"

--- a/src/main/resources/swagger.api/schemas/user.json
+++ b/src/main/resources/swagger.api/schemas/user.json
@@ -88,6 +88,20 @@
       "description": "Object that contains custom field",
       "type": "object",
       "additionalProperties": true
+    },
+    "preferredEmailCommunication": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "Support",
+          "Programs",
+          "Services"
+        ]
+      },
+      "maxItems": 3,
+      "uniqueItems": true,
+      "description": "Preferred email communication types"
     }
   },
   "additionalProperties": false

--- a/src/test/java/org/folio/uk/support/TestConstants.java
+++ b/src/test/java/org/folio/uk/support/TestConstants.java
@@ -1,6 +1,7 @@
 package org.folio.uk.support;
 
 import static java.time.OffsetDateTime.parse;
+import static org.folio.uk.domain.dto.User.PreferredEmailCommunicationEnum.SUPPORT;
 import static org.folio.uk.utils.UserUtils.ORIGINAL_TENANT_ID_CUSTOM_FIELD;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -48,7 +49,8 @@ public class TestConstants {
       .patronGroup(USER_PATRON_GROUP_ID)
       .enrollmentDate(USER_ENROLLMENT_DATE)
       .expirationDate(USER_EXPIRATION_DATE)
-      .personal(person(email));
+      .personal(person(email))
+      .preferredEmailCommunication(Set.of(SUPPORT));
   }
 
   public static User shadowUser() {
@@ -69,7 +71,8 @@ public class TestConstants {
     return new Personal()
       .firstName("Bailey")
       .lastName("Zakir")
-      .email(email);
+      .email(email)
+      .pronouns("he/him");
   }
 
   public static SystemUserEvent systemUserEvent(Set<String> permissions) {

--- a/src/test/resources/wiremock/stubs/users/create-module-system-user.json
+++ b/src/test/resources/wiremock/stubs/users/create-module-system-user.json
@@ -21,7 +21,8 @@
             "firstName": "System user - mod-foo",
             "addresses": [ ]
           },
-          "customFields" : { }
+          "customFields" : { },
+          "preferredEmailCommunication" : [ ]
         }
       }
     ]

--- a/src/test/resources/wiremock/stubs/users/update-user-id-notmatch.json
+++ b/src/test/resources/wiremock/stubs/users/update-user-id-notmatch.json
@@ -21,11 +21,13 @@
             "lastName": "Zakir",
             "firstName": "Bailey",
             "email": "new9@new.com",
+            "pronouns": "he/him",
             "addresses": [ ]
           },
           "enrollmentDate": "2020-10-07T04:00:00.000+00:00",
           "expirationDate": "2023-02-28T23:59:59.000+00:00",
-          "customFields" : { }
+          "customFields" : { },
+          "preferredEmailCommunication": [ "Support" ]
         }
       }
     ]

--- a/src/test/resources/wiremock/stubs/users/update-user-no-auth.json
+++ b/src/test/resources/wiremock/stubs/users/update-user-no-auth.json
@@ -21,11 +21,13 @@
             "lastName": "Zakir",
             "firstName": "Bailey",
             "email": "uuna@mail.com",
+            "pronouns": "he/him",
             "addresses": [ ]
           },
           "enrollmentDate": "2020-10-07T04:00:00.000+00:00",
           "expirationDate": "2023-02-28T23:59:59.000+00:00",
-          "customFields" : { }
+          "customFields" : { },
+          "preferredEmailCommunication": [ "Support" ]
         }
       }
     ]

--- a/src/test/resources/wiremock/stubs/users/update-user-notfound.json
+++ b/src/test/resources/wiremock/stubs/users/update-user-notfound.json
@@ -21,11 +21,13 @@
             "lastName": "Zakir",
             "firstName": "Bailey",
             "email": "uunf@mail.com",
+            "pronouns": "he/him",
             "addresses": [ ]
           },
           "enrollmentDate": "2020-10-07T04:00:00.000+00:00",
           "expirationDate": "2023-02-28T23:59:59.000+00:00",
-          "customFields" : {}
+          "customFields": {},
+          "preferredEmailCommunication": [ "Support" ]
         }
       }
     ]

--- a/src/test/resources/wiremock/stubs/users/update-user.json
+++ b/src/test/resources/wiremock/stubs/users/update-user.json
@@ -21,11 +21,13 @@
             "lastName": "Zakir",
             "firstName": "Bailey",
             "email": "uu@mail.com",
-            "addresses": [ ]
+            "pronouns": "he/him",
+            "addresses": []
           },
           "enrollmentDate": "2020-10-07T04:00:00.000+00:00",
           "expirationDate": "2023-02-28T23:59:59.000+00:00",
-          "customFields" : { }
+          "customFields": {},
+          "preferredEmailCommunication": [ "Support" ]
         }
       }
     ]


### PR DESCRIPTION
### **Purpose**
Jira Issue: https://folio-org.atlassian.net/browse/MODUSERSKC-94
`preferredEmailCommunication` and `personal.pronouns` fields are missing in mod-roles-keycloak.
When UI suggests converting a user to a auth-user, these fields became empty.

### **Approach**
- Add missing fields to `user.json` and `personal.json` model descriptors
- Adjust integration tests

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
