### PR TITLE
fix(token): use URL decoder for token payload

### DIFF
--- a/src/main/java/org/folio/uk/service/UserService.java
+++ b/src/main/java/org/folio/uk/service/UserService.java
@@ -269,7 +269,7 @@ public class UserService {
     }
     try {
       String encodedPayload = tokenParts[1];
-      byte[] decodedJsonBytes = Base64.getDecoder().decode(encodedPayload);
+      byte[] decodedJsonBytes = Base64.getUrlDecoder().decode(encodedPayload);
       String decodedJson = new String(decodedJsonBytes);
 
       return new JSONObject(decodedJson);


### PR DESCRIPTION
### **Purpose**
Illegal base64 character 2d error during the token parsing. See [MODLOGINKC-44](https://folio-org.atlassian.net/browse/MODLOGINKC-44)

### **Approach**
- use Base64.getUrlDecoder for token payload decoding

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
