### PR TITLE
MODUSERSKC-100 - SSO setting requires 'barcode' user attribute populated in Keycloak

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Default loadable roles for system users (MODUSERSKC-93)
 * Introduce configuration for FSSP (APPPOCTOOL-59)
 * Add missing fields to user DTO ([https://folio-org.atlassian.net/browse/MODUSERSKC-94](MODUSERSKC-94))
+* SSO setting requires 'barcode' user attribute populated in Keycloak ([https://folio-org.atlassian.net/browse/MODUSERSKC-100](MODUSERSKC-100))
 ---
 
 ## Version `v3.0.0` (14.03.2025)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * Default loadable roles for system users (MODUSERSKC-93)
 * Introduce configuration for FSSP (APPPOCTOOL-59)
 * Add missing fields to user DTO ([https://folio-org.atlassian.net/browse/MODUSERSKC-94](MODUSERSKC-94))
-* SSO setting requires 'barcode' user attribute populated in Keycloak ([https://folio-org.atlassian.net/browse/MODUSERSKC-100](MODUSERSKC-100))
+* SSO setting requires 'barcode' user attribute populated in Keycloak (MODUSERSKC-100)
 ---
 
 ## Version `v3.0.0` (14.03.2025)

--- a/src/main/java/org/folio/uk/integration/keycloak/KeycloakService.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/KeycloakService.java
@@ -435,6 +435,7 @@ public class KeycloakService {
 
     result.setUserIdAttr(user.getId());
     result.setUserExternalSystemIdAttr(user.getExternalSystemId());
+    result.setUserBarcodeAttr(user.getBarcode());
 
     return result;
   }

--- a/src/main/java/org/folio/uk/integration/keycloak/model/KeycloakUser.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/model/KeycloakUser.java
@@ -26,6 +26,7 @@ public class KeycloakUser implements Serializable {
   public static final String USER_ID_ATTR = "user_id";
   public static final String USER_TENANT_ATTR = "tenant_name";
   public static final String USER_EXTERNAL_SYSTEM_ID_ATTR = "external_system_id";
+  public static final String USER_BARCODE_ATTR = "barcode";
 
   @Serial
   private static final long serialVersionUID = 3279142822765797425L;
@@ -66,6 +67,15 @@ public class KeycloakUser implements Serializable {
       attributes.remove(USER_EXTERNAL_SYSTEM_ID_ATTR);
     } else {
       attributes.put(USER_EXTERNAL_SYSTEM_ID_ATTR, List.of(externalSystemId));
+    }
+  }
+
+  @JsonIgnore
+  public void setUserBarcodeAttr(String barcode) {
+    if (barcode == null) {
+      attributes.remove(USER_BARCODE_ATTR);
+    } else {
+      attributes.put(USER_BARCODE_ATTR, List.of(barcode));
     }
   }
 

--- a/src/test/java/org/folio/uk/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/uk/base/BaseIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.URL;
 import static org.folio.test.TestUtils.asJsonString;
 import static org.folio.test.extensions.impl.KeycloakContainerExtension.getKeycloakAdminClient;
+import static org.folio.uk.integration.keycloak.model.KeycloakUser.USER_BARCODE_ATTR;
 import static org.folio.uk.integration.keycloak.model.KeycloakUser.USER_EXTERNAL_SYSTEM_ID_ATTR;
 import static org.folio.uk.integration.keycloak.model.KeycloakUser.USER_ID_ATTR;
 import static org.folio.uk.support.TestConstants.CENTRAL_TENANT_NAME;
@@ -309,6 +310,7 @@ public abstract class BaseIntegrationTest extends BaseBackendIntegrationTest {
     assertThat(user.getId()).isNotNull();
     assertThat(attributes.get(USER_ID_ATTR)).contains(user.getId().toString());
     assertThat(attributes.get(USER_EXTERNAL_SYSTEM_ID_ATTR)).contains(user.getExternalSystemId());
+    assertThat(attributes.get(USER_BARCODE_ATTR)).contains(user.getBarcode());
   }
 
   protected CreateUserVerifyDto verifyKeycloakUser(String tenant, User user) {
@@ -322,6 +324,7 @@ public abstract class BaseIntegrationTest extends BaseBackendIntegrationTest {
     assertThat(user.getId()).isNotNull();
     assertThat(attributes.get(USER_ID_ATTR)).contains(user.getId().toString());
     assertThat(attributes.get(USER_EXTERNAL_SYSTEM_ID_ATTR)).contains(user.getExternalSystemId());
+    assertThat(attributes.get(USER_BARCODE_ATTR)).contains(user.getBarcode());
 
     return new CreateUserVerifyDto(authToken, kcUser);
   }


### PR DESCRIPTION
### **Purpose**
[MODUSERSKC-100](https://folio-org.atlassian.net/browse/MODUSERSKC-100) - SSO setting requires 'barcode' user attribute populated in Keycloak

### **Approach**
Add barcode attribute to migrated from FOLIO to Keycloak users.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
