### PR TITLE
MODUSERSKC-99: use SECURE_STORE_ENV, not ENV, for secure store key

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Introduce configuration for FSSP (APPPOCTOOL-59)
 * Add missing fields to user DTO ([https://folio-org.atlassian.net/browse/MODUSERSKC-94](MODUSERSKC-94))
 * SSO setting requires 'barcode' user attribute populated in Keycloak (MODUSERSKC-100)
+* Use SECURE_STORE_ENV, not ENV, for secure store key (MODUSERSKC-99)
 ---
 
 ## Version `v3.0.0` (14.03.2025)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ After that the documentation will be available in `target/docs/mod-users-keycloa
 
 ### Secure storage environment variables
 
+| Name                | Default value | Description                                                                                                                                                    |
+|:--------------------|:--------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SECURE_STORE_ENV    | folio         | First segment of the secure store key, for example `prod` or `test`. Defaults to `folio`. In Ramsons and Sunflower defaults to ENV with fall-back `folio`.     |
+
 #### AWS-SSM
 
 Required when `SECRET_STORE_TYPE=AWS_SSM`

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,6 +85,7 @@ application:
       trust-store-password: ${KC_CLIENT_TLS_TRUSTSTORE_PASSWORD:}
       trust-store-type: ${KC_CLIENT_TLS_TRUSTSTORE_TYPE:}
   secret-store:
+    environment: ${SECURE_STORE_ENV:${ENV}}
     type: ${SECRET_STORE_TYPE}
     aws-ssm:
       region: ${SECRET_STORE_AWS_SSM_REGION:}

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -21,6 +21,7 @@ application:
       trust-store-password: secretpassword
       trust-store-type: JKS
   secret-store:
+    environment: folio
     type: EPHEMERAL
     ephemeral:
       content:


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODUSERSKC-99
### **Approach**
- add env variable

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
