### PR TITLE
fix(pom): update argLine syntax for maven-failsafe-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
     <openapi-generator.version>7.21.0</openapi-generator.version>
     <folio-module-descriptor-validator.version>1.0.1</folio-module-descriptor-validator.version>
+    <argLine/>
 
     <sonar.exclusions>
       <!--
@@ -417,7 +418,7 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
         <configuration>
-          <argLine>${argLine} -Djdk.internal.httpclient.disableHostnameVerification=true</argLine>
+          <argLine>@{argLine} -Djdk.internal.httpclient.disableHostnameVerification=true</argLine>
           <groups>integration</groups>
         </configuration>
       </plugin>


### PR DESCRIPTION
### **Purpose**
The maven-failsafe-plugin was configured with `${argLine}`, which uses Maven's early property evaluation. When JaCoCo has not yet set the `argLine` property (e.g. in certain build profiles), this caused a build failure. Switching to `@{argLine}` defers evaluation until execution time, ensuring JaCoCo's agent arguments are picked up correctly. A default empty `<argLine/>`` property is also declared to prevent failures when the property is never set.

### **Approach**
- Added `<argLine/>` empty property declaration in `<properties>` to provide a safe default value
- Changed `${argLine}` to `@{argLine}` in `maven-failsafe-plugin` configuration to use Maven's late-binding property evaluation

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.