### PR TITLE
MODUSERSKC-148 - Entitlement does not reliably create secret store secrets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Adjust default behavior of _self endpoint to return ALL assigned permissions (MODUSERSKC-138)
 * Migrate module build from Jenkins to the centralized GitHub Maven workflow (MODUSERSKC-139)
 * Migrate to Spring Boot 4 (MODUSERSKC-108)
+* Entitlement does not reliably create secret store secrets (MODUSERSKC-148)
 ---
 
 ## Version `v3.0.0` (14.03.2025)

--- a/src/main/java/org/folio/uk/integration/kafka/KafkaMessageListener.java
+++ b/src/main/java/org/folio/uk/integration/kafka/KafkaMessageListener.java
@@ -1,7 +1,16 @@
 package org.folio.uk.integration.kafka;
 
+import static org.folio.common.utils.OkapiHeaders.URL;
+import static org.folio.spring.integration.XOkapiHeaders.TENANT;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.scope.FolioExecutionContextSetter;
+import org.folio.uk.integration.configuration.OkapiConfigurationProperties;
 import org.folio.uk.integration.kafka.model.ResourceEvent;
 import org.folio.uk.integration.kafka.model.SystemUserEvent;
 import org.folio.uk.integration.keycloak.SystemUserService;
@@ -15,7 +24,9 @@ import tools.jackson.databind.ObjectMapper;
 public class KafkaMessageListener {
 
   private final ObjectMapper objectMapper;
+  private final FolioModuleMetadata metadata;
   private final SystemUserService systemUserService;
+  private final OkapiConfigurationProperties okapiProperties;
 
   /**
    * Handles system user event.
@@ -29,15 +40,18 @@ public class KafkaMessageListener {
     topicPattern = "#{folioKafkaProperties.listener['system-user'].topicPattern}")
   public void handleSystemUserEvent(ResourceEvent event) {
     log.info("System user event received: {}", event);
-
-    switch (event.getType()) {
-      case UPDATE ->
-        systemUserService.updateOnEvent(objectMapper.convertValue(event.getNewValue(), SystemUserEvent.class));
-      case CREATE ->
-        systemUserService.createOnEvent(objectMapper.convertValue(event.getNewValue(), SystemUserEvent.class));
-      case DELETE ->
-        systemUserService.deleteOnEvent(objectMapper.convertValue(event.getOldValue(), SystemUserEvent.class));
-      default -> log.warn("Received system user event is not handled: {}", event);
+    Map<String, Collection<String>> headers =
+      Map.of(TENANT, List.of(event.getTenant()), URL, List.of(okapiProperties.getUrl()));
+    try (var ignored = new FolioExecutionContextSetter(metadata, headers)) {
+      switch (event.getType()) {
+        case UPDATE ->
+          systemUserService.updateOnEvent(objectMapper.convertValue(event.getNewValue(), SystemUserEvent.class));
+        case CREATE ->
+          systemUserService.createOnEvent(objectMapper.convertValue(event.getNewValue(), SystemUserEvent.class));
+        case DELETE ->
+          systemUserService.deleteOnEvent(objectMapper.convertValue(event.getOldValue(), SystemUserEvent.class));
+        default -> log.warn("Received system user event is not handled: {}", event);
+      }
     }
   }
 }

--- a/src/main/java/org/folio/uk/integration/kafka/KafkaMessageListener.java
+++ b/src/main/java/org/folio/uk/integration/kafka/KafkaMessageListener.java
@@ -1,21 +1,10 @@
 package org.folio.uk.integration.kafka;
 
-import static org.folio.common.utils.OkapiHeaders.URL;
-import static org.folio.spring.integration.XOkapiHeaders.TENANT;
-import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.getRunnableWithCurrentFolioContext;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.folio.spring.FolioModuleMetadata;
-import org.folio.spring.scope.FolioExecutionContextSetter;
-import org.folio.uk.integration.configuration.OkapiConfigurationProperties;
 import org.folio.uk.integration.kafka.model.ResourceEvent;
 import org.folio.uk.integration.kafka.model.SystemUserEvent;
 import org.folio.uk.integration.keycloak.SystemUserService;
-import org.springframework.core.task.TaskExecutor;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 import tools.jackson.databind.ObjectMapper;
@@ -26,10 +15,7 @@ import tools.jackson.databind.ObjectMapper;
 public class KafkaMessageListener {
 
   private final ObjectMapper objectMapper;
-  private final FolioModuleMetadata metadata;
   private final SystemUserService systemUserService;
-  private final TaskExecutor asyncTaskExecutor;
-  private final OkapiConfigurationProperties okapiProperties;
 
   /**
    * Handles system user event.
@@ -45,21 +31,13 @@ public class KafkaMessageListener {
     log.info("System user event received: {}", event);
 
     switch (event.getType()) {
-      case UPDATE -> executeWithContext(event,
-        () -> systemUserService.updateOnEvent(objectMapper.convertValue(event.getNewValue(), SystemUserEvent.class)));
-      case CREATE -> executeWithContext(event,
-        () -> systemUserService.createOnEvent(objectMapper.convertValue(event.getNewValue(), SystemUserEvent.class)));
-      case DELETE -> executeWithContext(event,
-        () -> systemUserService.deleteOnEvent(objectMapper.convertValue(event.getOldValue(), SystemUserEvent.class)));
+      case UPDATE ->
+        systemUserService.updateOnEvent(objectMapper.convertValue(event.getNewValue(), SystemUserEvent.class));
+      case CREATE ->
+        systemUserService.createOnEvent(objectMapper.convertValue(event.getNewValue(), SystemUserEvent.class));
+      case DELETE ->
+        systemUserService.deleteOnEvent(objectMapper.convertValue(event.getOldValue(), SystemUserEvent.class));
       default -> log.warn("Received system user event is not handled: {}", event);
-    }
-  }
-
-  private void executeWithContext(ResourceEvent event, Runnable task) {
-    Map<String, Collection<String>> headers =
-      Map.of(TENANT, List.of(event.getTenant()), URL, List.of(okapiProperties.getUrl()));
-    try (var ignored = new FolioExecutionContextSetter(metadata, headers)) {
-      asyncTaskExecutor.execute(getRunnableWithCurrentFolioContext(task));
     }
   }
 }

--- a/src/test/java/org/folio/uk/integration/kafka/KafkaMessageListenerTest.java
+++ b/src/test/java/org/folio/uk/integration/kafka/KafkaMessageListenerTest.java
@@ -1,6 +1,7 @@
 package org.folio.uk.integration.kafka;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Set;
@@ -58,6 +59,14 @@ class KafkaMessageListenerTest {
 
     kafkaMessageListener.handleSystemUserEvent(event);
     verify(systemUserService).createOnEvent(newValue);
+  }
+
+  @Test
+  void handleSystemUserEvent_positive_unhandledEventType() {
+    var event = ResourceEvent.builder().type(ResourceEventType.DELETE_ALL).tenant("tenant").build();
+
+    kafkaMessageListener.handleSystemUserEvent(event);
+    verifyNoInteractions(systemUserService);
   }
 
   private static SystemUserEvent getSystemUserEvent() {

--- a/src/test/java/org/folio/uk/integration/kafka/KafkaMessageListenerTest.java
+++ b/src/test/java/org/folio/uk/integration/kafka/KafkaMessageListenerTest.java
@@ -1,13 +1,16 @@
 package org.folio.uk.integration.kafka;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Set;
 import org.folio.test.types.UnitTest;
+import org.folio.uk.integration.configuration.OkapiConfigurationProperties;
 import org.folio.uk.integration.kafka.model.ResourceEvent;
 import org.folio.uk.integration.kafka.model.ResourceEventType;
 import org.folio.uk.integration.kafka.model.SystemUserEvent;
 import org.folio.uk.integration.keycloak.SystemUserService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,7 +25,13 @@ class KafkaMessageListenerTest {
 
   @Spy private ObjectMapper objectMapper = new ObjectMapper();
   @Mock private SystemUserService systemUserService;
+  @Mock private OkapiConfigurationProperties okapiProperties;
   @InjectMocks private KafkaMessageListener kafkaMessageListener;
+
+  @BeforeEach
+  void setUp() {
+    when(okapiProperties.getUrl()).thenReturn("dummy");
+  }
 
   @Test
   void handleSystemUserEvent_positive_deleteEvent() {

--- a/src/test/java/org/folio/uk/integration/kafka/KafkaMessageListenerTest.java
+++ b/src/test/java/org/folio/uk/integration/kafka/KafkaMessageListenerTest.java
@@ -1,54 +1,28 @@
 package org.folio.uk.integration.kafka;
 
-import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.Set;
-import org.awaitility.Durations;
 import org.folio.test.types.UnitTest;
-import org.folio.uk.integration.configuration.OkapiConfigurationProperties;
 import org.folio.uk.integration.kafka.model.ResourceEvent;
 import org.folio.uk.integration.kafka.model.ResourceEventType;
 import org.folio.uk.integration.kafka.model.SystemUserEvent;
 import org.folio.uk.integration.keycloak.SystemUserService;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import tools.jackson.databind.ObjectMapper;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 class KafkaMessageListenerTest {
 
-  @Spy private static ThreadPoolTaskExecutor asyncTaskExecutor = new ThreadPoolTaskExecutor();
   @Spy private ObjectMapper objectMapper = new ObjectMapper();
   @Mock private SystemUserService systemUserService;
-  @Mock private OkapiConfigurationProperties okapiProperties;
   @InjectMocks private KafkaMessageListener kafkaMessageListener;
-
-  @BeforeAll
-  static void beforeAll() {
-    asyncTaskExecutor.setCorePoolSize(1);
-    asyncTaskExecutor.initialize();
-  }
-
-  @AfterAll
-  static void afterAll() {
-    asyncTaskExecutor.shutdown();
-  }
-
-  @BeforeEach
-  void setUp() {
-    when(okapiProperties.getUrl()).thenReturn("dummy");
-  }
 
   @Test
   void handleSystemUserEvent_positive_deleteEvent() {
@@ -56,7 +30,7 @@ class KafkaMessageListenerTest {
     var event = ResourceEvent.builder().type(ResourceEventType.DELETE).tenant("tenant").oldValue(oldValue).build();
 
     kafkaMessageListener.handleSystemUserEvent(event);
-    await().atMost(Durations.FIVE_SECONDS).untilAsserted(() -> verify(systemUserService).deleteOnEvent(oldValue));
+    verify(systemUserService).deleteOnEvent(oldValue);
   }
 
   @Test
@@ -65,7 +39,7 @@ class KafkaMessageListenerTest {
     var event = ResourceEvent.builder().type(ResourceEventType.UPDATE).tenant("tenant").newValue(newValue).build();
 
     kafkaMessageListener.handleSystemUserEvent(event);
-    await().atMost(Durations.FIVE_SECONDS).untilAsserted(() -> verify(systemUserService).updateOnEvent(newValue));
+    verify(systemUserService).updateOnEvent(newValue);
   }
 
   @Test
@@ -74,7 +48,7 @@ class KafkaMessageListenerTest {
     var event = ResourceEvent.builder().type(ResourceEventType.CREATE).tenant("tenant").newValue(newValue).build();
 
     kafkaMessageListener.handleSystemUserEvent(event);
-    await().atMost(Durations.FIVE_SECONDS).untilAsserted(() -> verify(systemUserService).createOnEvent(newValue));
+    verify(systemUserService).createOnEvent(newValue);
   }
 
   private static SystemUserEvent getSystemUserEvent() {


### PR DESCRIPTION
### **Purpose**

[MODUSERSKC-148](https://folio-org.atlassian.net/browse/MODUSERSKC-148) - Entitlement does not reliably create secret store secrets

### **Approach**

Fixed an unreliable secret store secret creation during entitlement by eliminating the async execution model in `KafkaMessageListener`. When multiple Kafka `system-user` CREATE events arrived simultaneously, concurrent threads raced on a shared Vault path (`folio/{tenantId}`) via a non-atomic read-modify-write in `VaultStore.mergeSecrets()` of folio-secret-store library, causing missed some secrets .

## Implementation Details

### Modified Components

**`KafkaMessageListener`**

- Removed dependencies on `TaskExecutor`
- Replaced async invocations with direct synchronous calls to:
  - `systemUserService.updateOnEvent()`
  - `systemUserService.createOnEvent()`
  - `systemUserService.deleteOnEvent()`

### Testing Updates

**`KafkaMessageListenerTest`**
- Removed `@BeforeAll`/`@AfterAll` lifecycle methods that managed the `ThreadPoolTaskExecutor`
- Eliminated the `asyncTaskExecutor` spy and related setup
- Removed `await()` assertions that verified asynchronous task completion
- Tests now verify immediate synchronous method invocation without concurrency concerns
- Simplified test structure by removing async timing dependencies

### Configuration Changes

**`NEWS.md`**
- Added changelog entry: "Entitlement does not reliably create secret store secrets (MODUSERSKC-148)"

### Key Technical Decisions

**Synchronous over async processing** — Removing `asyncTaskExecutor` eliminates the concurrency that allowed threads to race on the shared Vault path. Kafka's own consumer-thread model provides sufficient concurrency control.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
