### PR TITLE
MODUSERSKC-161: Upgrade dependencies for Kafka 4.2 compatibility in mod-users-keycloak

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 ### Changes:
 * Users expiration field not working for eureka (MODUSERSKC-154)
 * Delete the Log4j configuration so the logging settings are automatically inherited from `folio-spring-base`. (EUREKA-889)
+* Upgrade dependencies for Kafka 4.2 compatibility in mod-users-keycloak (MODUSERSKC-161)
 ---
 
 ## Version `v4.0.0` (17.04.2026)

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
     <users-keycloak.yaml-file>${project.basedir}/src/main/resources/swagger.api/users-keycloak.yaml
     </users-keycloak.yaml-file>
 
+    <!-- overrides Spring Boot BOM default; can be removed once Spring Boot ships this version -->
+    <kafka.version>4.2.0</kafka.version>
+
     <!-- Plugins versions -->
     <maven-checkstyle.version>13.5.0</maven-checkstyle.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>


### PR DESCRIPTION
### **Purpose**
Fix [MODUSERSKC-161](https://folio-org.atlassian.net/browse/MODUSERSKC-161)

### **Approach**
Update pom with `<kafka.version>4.2.0</kafka.version>`

After the update, effective pom shows correct kafka version
<img width="1056" height="670" alt="image" src="https://github.com/user-attachments/assets/00fc5638-f317-4964-9089-13f453eece3c" />


---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
