### PR TITLE
MODUSERSKC-168: Fix -mod-users-keycloak unnecessarily retries already assigned user-role relation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Delete the Log4j configuration so the logging settings are automatically inherited from `folio-spring-base`. (EUREKA-889)
 * Upgrade dependencies for Kafka 4.2 compatibility in mod-users-keycloak (MODUSERSKC-161)
 * Fix system-user password SSM key to match sidecar (MODUSERSKC-167)
+* Avoid retrying system-user role assignment when the user-role relation already exists (MODUSERSKC-168)
 ---
 
 ## Version `v4.0.0` (17.04.2026)

--- a/src/main/java/org/folio/uk/integration/roles/dafaultrole/DefaultSystemUserRoleService.java
+++ b/src/main/java/org/folio/uk/integration/roles/dafaultrole/DefaultSystemUserRoleService.java
@@ -1,8 +1,12 @@
 package org.folio.uk.integration.roles.dafaultrole;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.uk.domain.dto.Error;
+import org.folio.uk.domain.dto.ErrorResponse;
 import org.folio.uk.domain.dto.User;
 import org.folio.uk.integration.roles.UserRolesClient;
 import org.folio.uk.integration.roles.model.LoadablePermission;
@@ -11,6 +15,9 @@ import org.folio.uk.integration.roles.model.UserRoles;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientResponseException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 @Service
 @Log4j2
@@ -18,10 +25,12 @@ import org.springframework.stereotype.Service;
 public class DefaultSystemUserRoleService {
 
   private static final String DEFAULT_SYSTEM_USER_ROLE_NAME = "default-system-role-";
+  private static final String ENTITY_EXISTS_EXCEPTION = "EntityExistsException";
 
   private final DefaultRolesClient defaultRolesClient;
   private final UserRolesClient userRolesClient;
   @Qualifier("systemUserRoleRetryTemplate") private final RetryTemplate retryTemplate;
+  private final ObjectMapper objectMapper;
 
   public void createAndAssignDefaultRole(User user, List<String> permissions) {
     retryTemplate.execute(ctx -> {
@@ -30,15 +39,30 @@ public class DefaultSystemUserRoleService {
       var createdRole = defaultRolesClient.createDefaultLoadableRole(defaultRole);
       log.debug("Created default role: role = {}", createdRole);
 
-      log.info("Assigning default role to user: roleName = {}, username = {}", createdRole.getName(),
-        user.getUsername());
-      var userRoleRequest = buildRoleUserRequest(user, createdRole);
-      userRolesClient.assignRoleToUser(userRoleRequest);
-      log.debug("Assigned default role to user: roleName = {}, username = {}", createdRole.getName(),
-        user.getUsername());
+      assignRoleToUser(user, createdRole);
 
       return null;
     });
+  }
+
+  private void assignRoleToUser(User user, LoadableRole createdRole) {
+    log.info("Assigning default role to user: roleName = {}, username = {}", createdRole.getName(),
+      user.getUsername());
+    var userRoleRequest = buildRoleUserRequest(user, createdRole);
+    try {
+      userRolesClient.assignRoleToUser(userRoleRequest);
+    } catch (RestClientResponseException e) {
+      if (isUserRoleAlreadyAssigned(e)) {
+        log.info("Default role is already assigned to user: roleName = {}, username = {}",
+          createdRole.getName(), user.getUsername());
+        return;
+      }
+
+      throw e;
+    }
+
+    log.debug("Assigned default role to user: roleName = {}, username = {}", createdRole.getName(),
+      user.getUsername());
   }
 
   private static UserRoles buildRoleUserRequest(User user, LoadableRole createdRole) {
@@ -56,5 +80,26 @@ public class DefaultSystemUserRoleService {
       .map(LoadablePermission::of)
       .toList());
     return defaultRole;
+  }
+
+  private boolean isUserRoleAlreadyAssigned(RestClientResponseException exception) {
+    if (!exception.getStatusCode().isSameCodeAs(BAD_REQUEST)) {
+      return false;
+    }
+
+    try {
+      var errors = objectMapper.readValue(exception.getResponseBodyAsString(), ErrorResponse.class).getErrors();
+      if (errors == null) {
+        return false;
+      }
+
+      return errors.stream().anyMatch(DefaultSystemUserRoleService::isUserRoleAlreadyAssignedError);
+    } catch (JacksonException e) {
+      return false;
+    }
+  }
+
+  private static boolean isUserRoleAlreadyAssignedError(Error error) {
+    return ENTITY_EXISTS_EXCEPTION.equals(error.getType());
   }
 }

--- a/src/test/java/org/folio/uk/integration/roles/dafaultrole/DefaultSystemUserRoleServiceTest.java
+++ b/src/test/java/org/folio/uk/integration/roles/dafaultrole/DefaultSystemUserRoleServiceTest.java
@@ -1,16 +1,20 @@
 package org.folio.uk.integration.roles.dafaultrole;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.folio.test.types.UnitTest;
+import org.folio.uk.domain.dto.Error;
+import org.folio.uk.domain.dto.ErrorResponse;
 import org.folio.uk.domain.dto.User;
 import org.folio.uk.integration.roles.UserRolesClient;
 import org.folio.uk.integration.roles.model.LoadablePermission;
@@ -22,8 +26,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.web.client.HttpClientErrorException;
+import tools.jackson.databind.ObjectMapper;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +42,7 @@ class DefaultSystemUserRoleServiceTest {
   @Mock private DefaultRolesClient defaultRolesClient;
   @Mock private UserRolesClient userRolesClient;
   @Mock private RetryTemplate retryTemplate;
+  @Mock private ObjectMapper objectMapper;
 
   @BeforeEach
   void setUp() {
@@ -82,7 +91,7 @@ class DefaultSystemUserRoleServiceTest {
 
   @Test
   void createAndAssignDefaultRole_negative_roleCreationError() {
-    var userId = randomUUID();
+    final var userId = randomUUID();
     var username = "error-user";
     var user = new User().id(userId).username(username);
     var permissions = List.of("permission.one");
@@ -121,5 +130,68 @@ class DefaultSystemUserRoleServiceTest {
     verify(retryTemplate).execute(any());
     verify(defaultRolesClient).createDefaultLoadableRole(any());
     verify(userRolesClient).assignRoleToUser(any());
+  }
+
+  @Test
+  void createAndAssignDefaultRole_positive_userRoleAlreadyAssigned() throws Exception {
+    final var userId = randomUUID();
+    var username = "assigned-user";
+    var roleId = randomUUID();
+    var createdRole = new LoadableRole();
+    createdRole.setId(roleId);
+    createdRole.setName("default-system-role-" + username);
+
+    when(defaultRolesClient.createDefaultLoadableRole(any())).thenReturn(createdRole);
+    when(userRolesClient.assignRoleToUser(any())).thenThrow(badRequestError());
+    when(objectMapper.readValue(any(String.class), eq(ErrorResponse.class)))
+      .thenReturn(errorResponse("EntityExistsException"));
+
+    var user = new User().id(userId).username(username);
+    var permissions = List.of("permission.one");
+
+    defaultSystemUserRoleService.createAndAssignDefaultRole(user, permissions);
+
+    verify(retryTemplate).execute(any());
+    verify(defaultRolesClient).createDefaultLoadableRole(any());
+    verify(userRolesClient).assignRoleToUser(any());
+    verify(objectMapper).readValue(any(String.class), eq(ErrorResponse.class));
+  }
+
+  @Test
+  void createAndAssignDefaultRole_negative_roleAssigningToUserBadRequestError() throws Exception {
+    var userId = randomUUID();
+    var username = "bad-request-user";
+    var roleId = randomUUID();
+    var createdRole = new LoadableRole();
+    createdRole.setId(roleId);
+    createdRole.setName("default-system-role-" + username);
+    var user = new User().id(userId).username(username);
+    var permissions = List.of("permission.one");
+
+    when(defaultRolesClient.createDefaultLoadableRole(any())).thenReturn(createdRole);
+    when(userRolesClient.assignRoleToUser(any())).thenThrow(badRequestError());
+    when(objectMapper.readValue(any(String.class), eq(ErrorResponse.class)))
+      .thenReturn(errorResponse("ValidationException"));
+
+    assertThatThrownBy(() -> defaultSystemUserRoleService.createAndAssignDefaultRole(user, permissions))
+      .isInstanceOf(HttpClientErrorException.BadRequest.class);
+
+    verify(retryTemplate).execute(any());
+    verify(defaultRolesClient).createDefaultLoadableRole(any());
+    verify(userRolesClient).assignRoleToUser(any());
+    verify(objectMapper).readValue(any(String.class), eq(ErrorResponse.class));
+  }
+
+  private static HttpClientErrorException badRequestError() {
+    var body = """
+      {"errors":[{"code":"found_error","message":"error","parameters":[],"type":"EntityExistsException"}]}
+      """;
+
+    return HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "Bad Request", HttpHeaders.EMPTY,
+      body.getBytes(UTF_8), UTF_8);
+  }
+
+  private static ErrorResponse errorResponse(String type) {
+    return new ErrorResponse().errors(List.of(new Error().type(type)));
   }
 }


### PR DESCRIPTION
### **Purpose**
Fix for [MODUSERSKC-168](https://folio-org.atlassian.net/browse/MODUSERSKC-168)

### **Approach**
Do not retry `userRolesClient.assignRoleToUser(userRoleRequest);` when the role is already assigned to user.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
