### PR TITLE
[Backport] MODUSERSKC-167 / MODUSERSKC-169: Fix system-user password SSM key to match sidecar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## Version `v4.0.3` (IN PROGRESS)
+### Changes:
+* Fix system-user password SSM key to match sidecar (MODUSERSKC-167)
+
 ## Version `v4.0.2` (22.05.2026)
 ### Changes:
 * Users expiration field not working for eureka (MODUSERSKC-154)

--- a/src/main/java/org/folio/uk/integration/keycloak/SystemUserPasswordService.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/SystemUserPasswordService.java
@@ -1,0 +1,77 @@
+package org.folio.uk.integration.keycloak;
+
+import static org.folio.common.configuration.properties.FolioEnvironment.getFolioEnvName;
+import static org.folio.tools.store.utils.SecretGenerator.generateSecret;
+
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.tools.store.SecureStore;
+import org.folio.tools.store.properties.SecureStoreProperties;
+import org.folio.uk.configuration.SystemUserConfigurationProperties;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class SystemUserPasswordService {
+
+  private final SecureStore secureStore;
+  private final SecureStoreProperties secureStoreProperties;
+  private final SystemUserConfigurationProperties systemUserConfiguration;
+
+  public String getOrCreatePassword(String tenant, String username) {
+    var systemUserKey = getSystemUserStoreKey(secureStoreProperties.getEnvironment(), tenant, username);
+    return secureStore.lookup(systemUserKey)
+      .or(() -> migrateLegacyPassword(systemUserKey, tenant, username))
+      .orElseGet(() -> generateAndSavePassword(systemUserKey));
+  }
+
+  public void migrateLegacyPasswordIfNeeded(String tenant, String username) {
+    // A legacy password is an existing system-user password stored under the old ENV-derived key.
+    // Copy it to the SECURE_STORE_ENV-derived key so the sidecar can read the same credential.
+
+    var systemUserKey = getSystemUserStoreKey(secureStoreProperties.getEnvironment(), tenant, username);
+    if (secureStore.lookup(systemUserKey).isPresent()) {
+      return;
+    }
+
+    migrateLegacyPassword(systemUserKey, tenant, username);
+  }
+
+  private Optional<String> migrateLegacyPassword(String systemUserKey, String tenant, String username) {
+    var legacyKey = getLegacySystemUserStoreKey(tenant, username);
+    if (Objects.equals(systemUserKey, legacyKey)) {
+      return Optional.empty();
+    }
+
+    return secureStore.lookup(legacyKey)
+      .map(password -> saveLegacyPassword(systemUserKey, legacyKey, password));
+  }
+
+  private static String getSystemUserStoreKey(String env, String tenant, String username) {
+    return String.format("%s_%s_%s", env, tenant, username);
+  }
+
+  private static String getLegacySystemUserStoreKey(String tenant, String username) {
+    return getSystemUserStoreKey(getFolioEnvName(), tenant, username);
+  }
+
+  private String saveLegacyPassword(String systemUserKey, String legacyKey, String password) {
+    log.debug("Found legacy system user password, copying to new key [legacyKey: {}, key: {}]",
+      legacyKey, systemUserKey);
+    return savePassword(systemUserKey, password);
+  }
+
+  private String generateAndSavePassword(String key) {
+    log.debug("Generating system user password [key: {}]", key);
+    var secret = generateSecret(systemUserConfiguration.getPasswordLength());
+    return savePassword(key, secret);
+  }
+
+  private String savePassword(String key, String secret) {
+    secureStore.set(key, secret);
+    return secret;
+  }
+}

--- a/src/main/java/org/folio/uk/integration/keycloak/SystemUserService.java
+++ b/src/main/java/org/folio/uk/integration/keycloak/SystemUserService.java
@@ -1,8 +1,6 @@
 package org.folio.uk.integration.keycloak;
 
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
-import static org.folio.common.configuration.properties.FolioEnvironment.getFolioEnvName;
-import static org.folio.tools.store.utils.SecretGenerator.generateSecret;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -12,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.spring.FolioExecutionContext;
-import org.folio.tools.store.SecureStore;
 import org.folio.uk.configuration.SystemUserConfigurationProperties;
 import org.folio.uk.domain.dto.Personal;
 import org.folio.uk.domain.dto.User;
@@ -28,12 +25,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SystemUserService {
 
-  private final SecureStore secureStore;
   private final UserService userService;
   private final KeycloakService keycloakService;
   private final FolioExecutionContext executionContext;
   private final SystemUserConfigurationProperties systemUserConfiguration;
   private final DefaultSystemUserRoleService defaultSystemUserRoleService;
+  private final SystemUserPasswordService systemUserPasswordService;
 
   /**
    * Creates a system user for tenant.
@@ -67,7 +64,10 @@ public class SystemUserService {
     }
     var username = event.getName();
     findUserByUsername(username).ifPresentOrElse(
-      user -> recreateAndAssignRole(user, event.getPermissions()),
+      user -> {
+        systemUserPasswordService.migrateLegacyPasswordIfNeeded(executionContext.getTenantId(), username);
+        recreateAndAssignRole(user, event.getPermissions());
+      },
       () -> createOnEvent(event));
   }
 
@@ -112,8 +112,7 @@ public class SystemUserService {
         .firstName(firstName)
         .lastName("System"));
 
-    var systemUserKey = getSystemUserStoreKey(tenantId, username);
-    var systemUserPassword = secureStore.lookup(systemUserKey).orElseGet(() -> generateAndSavePassword(systemUserKey));
+    var systemUserPassword = systemUserPasswordService.getOrCreatePassword(tenantId, username);
 
     return userService.createUserSafe(user, systemUserPassword, false);
   }
@@ -137,15 +136,5 @@ public class SystemUserService {
 
   private String generateValueByTemplate(String template) {
     return template.replace("{tenantId}", executionContext.getTenantId());
-  }
-
-  public static String getSystemUserStoreKey(String tenant, String username) {
-    return String.format("%s_%s_%s", getFolioEnvName(), tenant, username);
-  }
-
-  private String generateAndSavePassword(String key) {
-    var secret = generateSecret(systemUserConfiguration.getPasswordLength());
-    secureStore.set(key, secret);
-    return secret;
   }
 }

--- a/src/test/java/org/folio/uk/integration/keycloak/SystemUserPasswordServiceTest.java
+++ b/src/test/java/org/folio/uk/integration/keycloak/SystemUserPasswordServiceTest.java
@@ -1,0 +1,125 @@
+package org.folio.uk.integration.keycloak;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.folio.test.types.UnitTest;
+import org.folio.tools.store.SecureStore;
+import org.folio.tools.store.properties.SecureStoreProperties;
+import org.folio.uk.configuration.SystemUserConfigurationProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class SystemUserPasswordServiceTest {
+
+  private static final String TENANT = "test";
+  private static final String USERNAME = "mod-foo";
+  private static final String SECURE_STORE_ENV = "secure-test";
+  private static final String SYSTEM_USER_STORE_KEY = "secure-test_test_mod-foo";
+  private static final String LEGACY_SYSTEM_USER_STORE_KEY = "folio_test_mod-foo";
+
+  @InjectMocks private SystemUserPasswordService systemUserPasswordService;
+
+  @Mock private SecureStore secureStore;
+  @Mock private SecureStoreProperties secureStoreProperties;
+
+  @Spy private final SystemUserConfigurationProperties userConfiguration = new SystemUserConfigurationProperties();
+  @Captor private ArgumentCaptor<String> passwordCaptor;
+
+  @Test
+  void getOrCreatePassword_positive_existingSecureStorePassword_passwordIsReused() {
+    var storedPassword = "system-user-password";
+    when(secureStoreProperties.getEnvironment()).thenReturn(SECURE_STORE_ENV);
+    when(secureStore.lookup(SYSTEM_USER_STORE_KEY)).thenReturn(Optional.of(storedPassword));
+
+    var result = systemUserPasswordService.getOrCreatePassword(TENANT, USERNAME);
+
+    assertThat(result).isEqualTo(storedPassword);
+    verify(secureStore, never()).set(any(), any());
+  }
+
+  @Test
+  void getOrCreatePassword_positive_existingLegacyPassword_passwordIsMigrated() {
+    var storedPassword = "legacy-system-user-password";
+    when(secureStoreProperties.getEnvironment()).thenReturn(SECURE_STORE_ENV);
+    when(secureStore.lookup(SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+    when(secureStore.lookup(LEGACY_SYSTEM_USER_STORE_KEY)).thenReturn(Optional.of(storedPassword));
+
+    var result = systemUserPasswordService.getOrCreatePassword(TENANT, USERNAME);
+
+    assertThat(result).isEqualTo(storedPassword);
+    verify(secureStore).set(SYSTEM_USER_STORE_KEY, storedPassword);
+  }
+
+  @Test
+  void getOrCreatePassword_positive_passwordIsMissing_passwordIsGenerated() {
+    when(secureStoreProperties.getEnvironment()).thenReturn(SECURE_STORE_ENV);
+    when(secureStore.lookup(SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+    when(secureStore.lookup(LEGACY_SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+
+    var result = systemUserPasswordService.getOrCreatePassword(TENANT, USERNAME);
+
+    assertThat(result).hasSize(userConfiguration.getPasswordLength());
+    verify(secureStore).set(eq(SYSTEM_USER_STORE_KEY), passwordCaptor.capture());
+    assertThat(passwordCaptor.getValue()).isEqualTo(result);
+  }
+
+  @Test
+  void migrateLegacyPasswordIfNeeded_positive_secureStorePasswordExists_passwordIsNotMigrated() {
+    when(secureStoreProperties.getEnvironment()).thenReturn(SECURE_STORE_ENV);
+    when(secureStore.lookup(SYSTEM_USER_STORE_KEY)).thenReturn(Optional.of("system-user-password"));
+
+    systemUserPasswordService.migrateLegacyPasswordIfNeeded(TENANT, USERNAME);
+
+    verify(secureStore, never()).lookup(LEGACY_SYSTEM_USER_STORE_KEY);
+    verify(secureStore, never()).set(any(), any());
+  }
+
+  @Test
+  void migrateLegacyPasswordIfNeeded_positive_legacyPasswordExists_passwordIsMigrated() {
+    var storedPassword = "legacy-system-user-password";
+    when(secureStoreProperties.getEnvironment()).thenReturn(SECURE_STORE_ENV);
+    when(secureStore.lookup(SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+    when(secureStore.lookup(LEGACY_SYSTEM_USER_STORE_KEY)).thenReturn(Optional.of(storedPassword));
+
+    systemUserPasswordService.migrateLegacyPasswordIfNeeded(TENANT, USERNAME);
+
+    verify(secureStore).set(SYSTEM_USER_STORE_KEY, storedPassword);
+  }
+
+  @Test
+  void migrateLegacyPasswordIfNeeded_positive_passwordIsMissing_passwordIsNotGenerated() {
+    when(secureStoreProperties.getEnvironment()).thenReturn(SECURE_STORE_ENV);
+    when(secureStore.lookup(SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+    when(secureStore.lookup(LEGACY_SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+
+    systemUserPasswordService.migrateLegacyPasswordIfNeeded(TENANT, USERNAME);
+
+    verify(userConfiguration, never()).getPasswordLength();
+    verify(secureStore, never()).set(any(), any());
+  }
+
+  @Test
+  void migrateLegacyPasswordIfNeeded_positive_legacyAndSecureStoreKeysMatch_passwordIsNotGenerated() {
+    when(secureStoreProperties.getEnvironment()).thenReturn("folio");
+    when(secureStore.lookup(LEGACY_SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+
+    systemUserPasswordService.migrateLegacyPasswordIfNeeded(TENANT, USERNAME);
+
+    verify(userConfiguration, never()).getPasswordLength();
+    verify(secureStore, never()).set(any(), any());
+  }
+}

--- a/src/test/java/org/folio/uk/integration/keycloak/SystemUserServiceTest.java
+++ b/src/test/java/org/folio/uk/integration/keycloak/SystemUserServiceTest.java
@@ -5,19 +5,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.test.types.UnitTest;
-import org.folio.tools.store.SecureStore;
 import org.folio.uk.configuration.SystemUserConfigurationProperties;
 import org.folio.uk.domain.dto.Personal;
 import org.folio.uk.domain.dto.User;
@@ -44,9 +41,8 @@ class SystemUserServiceTest {
 
   private static final String TENANT = "test";
   private static final String USERNAME = "test-system-user";
-  private static final String SYSTEM_USER_STORE_KEY = "folio_test_test-system-user";
   private static final String MODULE_SYSTEM_USERNAME = "mod-foo";
-  private static final String MODULE_SYSTEM_USER_STORE_KEY = "folio_test_mod-foo";
+  private static final String SYSTEM_USER_PASSWORD = "system-user-password";
   private static final String KEYCLOAK_USER_ID = UUID.randomUUID().toString();
   private static final String SYSTEM_ROLE = "System";
   private static final UUID CAPABILITY_ID = UUID.randomUUID();
@@ -54,11 +50,11 @@ class SystemUserServiceTest {
 
   @InjectMocks private SystemUserService systemUserService;
 
-  @Mock private SecureStore secureStore;
   @Mock private UserService userService;
   @Mock private DefaultSystemUserRoleService defaultSystemUserRoleService;
   @Mock private KeycloakService keycloakService;
   @Mock private FolioExecutionContext folioExecutionContext;
+  @Mock private SystemUserPasswordService systemUserPasswordService;
 
   @Spy private final SystemUserConfigurationProperties userConfiguration = new SystemUserConfigurationProperties();
   @Captor private ArgumentCaptor<User> userCaptor;
@@ -66,13 +62,13 @@ class SystemUserServiceTest {
 
   @AfterEach
   void tearDown() {
-    verifyNoMoreInteractions(secureStore, userService, keycloakService);
+    verifyNoMoreInteractions(userService, keycloakService, systemUserPasswordService);
   }
 
   @Test
   void create_positive_freshSetup() {
     when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
-    when(secureStore.lookup(SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+    givenSystemUserPassword(USERNAME);
     when(userService.createUserSafe(userCaptor.capture(), passwordCaptor.capture(), eq(false))).then(firstArg());
     when(keycloakService.findUserByUsername(USERNAME)).thenReturn(Optional.of(keycloakUser()));
     when(keycloakService.hasRole(KEYCLOAK_USER_ID, SYSTEM_ROLE)).thenReturn(false);
@@ -82,53 +78,48 @@ class SystemUserServiceTest {
     verify(userConfiguration).getSystemUserRole();
     verify(userConfiguration).getEmailTemplate();
     verify(userConfiguration).getUsernameTemplate();
-    verify(userConfiguration).getPasswordLength();
 
-    var capturedPassword = passwordCaptor.getValue();
-    assertThat(passwordCaptor.getValue()).hasSize(userConfiguration.getPasswordLength());
+    assertThat(passwordCaptor.getValue()).isEqualTo(SYSTEM_USER_PASSWORD);
     assertThat(userCaptor.getValue()).usingRecursiveComparison().ignoringFields("id").isEqualTo(systemUser());
     assertThat(userCaptor.getValue().getId()).isNotNull();
 
-    verify(secureStore).set(SYSTEM_USER_STORE_KEY, capturedPassword);
+    verify(systemUserPasswordService).getOrCreatePassword(TENANT, USERNAME);
     verify(keycloakService).assignRole(KEYCLOAK_USER_ID, SYSTEM_ROLE);
   }
 
   @Test
   void create_positive_userExistsAndRoleNotFound() {
     when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
-    when(secureStore.lookup(SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+    givenSystemUserPassword(USERNAME);
     when(userService.createUserSafe(userCaptor.capture(), passwordCaptor.capture(), eq(false))).then(firstArg());
     when(keycloakService.findUserByUsername(USERNAME)).thenReturn(Optional.of(keycloakUser()));
     when(keycloakService.hasRole(KEYCLOAK_USER_ID, SYSTEM_ROLE)).thenReturn(false);
 
     systemUserService.create();
 
-    var capturedPassword = passwordCaptor.getValue();
-    assertThat(new HashSet<>(passwordCaptor.getAllValues())).hasSize(1);
-    assertThat(capturedPassword).hasSize(userConfiguration.getPasswordLength());
-    verify(secureStore).set(SYSTEM_USER_STORE_KEY, capturedPassword);
+    assertThat(passwordCaptor.getValue()).isEqualTo(SYSTEM_USER_PASSWORD);
+    verify(systemUserPasswordService).getOrCreatePassword(TENANT, USERNAME);
     verify(keycloakService).assignRole(KEYCLOAK_USER_ID, SYSTEM_ROLE);
   }
 
   @Test
   void create_positive_userExistsAndRoleIsFound() {
     when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
-    when(secureStore.lookup(SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+    givenSystemUserPassword(USERNAME);
     when(userService.createUserSafe(userCaptor.capture(), passwordCaptor.capture(), eq(false))).then(firstArg());
     when(keycloakService.findUserByUsername(USERNAME)).thenReturn(Optional.of(keycloakUser()));
     when(keycloakService.hasRole(KEYCLOAK_USER_ID, SYSTEM_ROLE)).thenReturn(true);
 
     systemUserService.create();
 
-    var capturedPassword = passwordCaptor.getValue();
-    assertThat(passwordCaptor.getValue()).hasSize(userConfiguration.getPasswordLength());
-    verify(secureStore).set(SYSTEM_USER_STORE_KEY, capturedPassword);
+    assertThat(passwordCaptor.getValue()).isEqualTo(SYSTEM_USER_PASSWORD);
+    verify(systemUserPasswordService).getOrCreatePassword(TENANT, USERNAME);
   }
 
   @Test
   void create_negative_userByUsernameIsNotFound() {
     when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
-    when(secureStore.lookup(SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+    givenSystemUserPassword(USERNAME);
     when(userService.createUserSafe(userCaptor.capture(), passwordCaptor.capture(), eq(false))).then(firstArg());
     when(keycloakService.findUserByUsername(USERNAME)).thenReturn(Optional.empty());
 
@@ -136,51 +127,62 @@ class SystemUserServiceTest {
       .isInstanceOf(KeycloakException.class)
       .hasMessage("Failed to find a system user by username: " + USERNAME);
 
-    var capturedPassword = passwordCaptor.getValue();
-    assertThat(passwordCaptor.getValue()).hasSize(userConfiguration.getPasswordLength());
-    verify(secureStore).set(SYSTEM_USER_STORE_KEY, capturedPassword);
+    assertThat(passwordCaptor.getValue()).isEqualTo(SYSTEM_USER_PASSWORD);
+    verify(systemUserPasswordService).getOrCreatePassword(TENANT, USERNAME);
   }
 
   @Test
   void createOnEvent_positive_freshSetup() {
     when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
-    when(secureStore.lookup(MODULE_SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+    givenSystemUserPassword(MODULE_SYSTEM_USERNAME);
     when(userService.createUserSafe(userCaptor.capture(), passwordCaptor.capture(), eq(false))).then(firstArg());
 
     systemUserService.createOnEvent(TestConstants.systemUser(Set.of(PERMISSION)));
 
-    verify(userConfiguration).getPasswordLength();
-
-    var capturedPassword = passwordCaptor.getValue();
-    assertThat(passwordCaptor.getValue()).hasSize(userConfiguration.getPasswordLength());
+    assertThat(passwordCaptor.getValue()).isEqualTo(SYSTEM_USER_PASSWORD);
     assertThat(userCaptor.getValue()).usingRecursiveComparison().ignoringFields("id").isEqualTo(moduleUser());
     assertThat(userCaptor.getValue().getId()).isNotNull();
 
-    verify(secureStore).set(MODULE_SYSTEM_USER_STORE_KEY, capturedPassword);
+    verify(systemUserPasswordService).getOrCreatePassword(TENANT, MODULE_SYSTEM_USERNAME);
+  }
+
+  @Test
+  void createOnEvent_positive_usesPasswordServicePassword() {
+    var storedPassword = "system-user-password";
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
+    when(systemUserPasswordService.getOrCreatePassword(TENANT, MODULE_SYSTEM_USERNAME)).thenReturn(storedPassword);
+    when(userService.createUserSafe(userCaptor.capture(), passwordCaptor.capture(), eq(false))).then(firstArg());
+
+    systemUserService.createOnEvent(TestConstants.systemUser(Set.of(PERMISSION)));
+
+    assertThat(passwordCaptor.getValue()).isEqualTo(storedPassword);
+    verify(systemUserPasswordService).getOrCreatePassword(TENANT, MODULE_SYSTEM_USERNAME);
   }
 
   @Test
   void updateOnEvent_positive_userFound() {
     var user = systemUser().id(CAPABILITY_ID);
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
     when(userService.findUsers("username==\"mod-foo\"", 1)).thenReturn(new Users().addUsersItem(user));
 
     systemUserService.updateOnEvent(TestConstants.systemUser(Set.of(PERMISSION)));
 
-    verify(folioExecutionContext, never()).getTenantId();
+    verify(systemUserPasswordService).migrateLegacyPasswordIfNeeded(TENANT, MODULE_SYSTEM_USERNAME);
   }
 
   @Test
   void updateOnEvent_positive_userNotFoundThenCreate() {
     when(folioExecutionContext.getTenantId()).thenReturn(TENANT);
-    when(secureStore.lookup(MODULE_SYSTEM_USER_STORE_KEY)).thenReturn(Optional.empty());
+    givenSystemUserPassword(MODULE_SYSTEM_USERNAME);
     when(userService.findUsers("username==\"mod-foo\"", 1)).thenReturn(new Users());
-    when(userService.createUserSafe(userCaptor.capture(), any(), eq(false))).then(firstArg());
-    doNothing().when(secureStore).set(any(), any());
+    when(userService.createUserSafe(userCaptor.capture(), passwordCaptor.capture(), eq(false))).then(firstArg());
 
     systemUserService.updateOnEvent(TestConstants.systemUser(Set.of(PERMISSION)));
 
     assertThat(userCaptor.getValue()).usingRecursiveComparison().ignoringFields("id").isEqualTo(moduleUser());
     assertThat(userCaptor.getValue().getId()).isNotNull();
+    assertThat(passwordCaptor.getValue()).isEqualTo(SYSTEM_USER_PASSWORD);
+    verify(systemUserPasswordService).getOrCreatePassword(TENANT, MODULE_SYSTEM_USERNAME);
   }
 
   @Test
@@ -250,6 +252,10 @@ class SystemUserServiceTest {
   @NotNull
   private static Answer<Object> firstArg() {
     return i -> i.getArgument(0);
+  }
+
+  private void givenSystemUserPassword(String username) {
+    when(systemUserPasswordService.getOrCreatePassword(TENANT, username)).thenReturn(SYSTEM_USER_PASSWORD);
   }
 
   private static KeycloakUser keycloakUser() {


### PR DESCRIPTION
### **Purpose**

Backport https://github.com/folio-org/mod-users-keycloak/pull/243 to Trillium


### **Approach**
Provide a brief technical summary of the changes.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
